### PR TITLE
poseidon parameters: generate round constants

### DIFF
--- a/poseidon-paramgen/src/alpha.rs
+++ b/poseidon-paramgen/src/alpha.rs
@@ -38,7 +38,7 @@ pub enum Alpha {
 
 impl Alpha {
     /// Select the best choice of `Alpha` given the parameters.
-    pub fn generate<F: PrimeField>(p: F::BigInt) -> Self {
+    pub fn generate<F: PrimeField>(p: F::BigInt, allow_inverse: bool) -> Self {
         // Move through the addition chains in increasing depth,
         // picking the leftmost choice that meets the coprime requirement.
         for candidate in SHORTEST_ADDITION_CHAINS.depths_in_order() {
@@ -47,7 +47,11 @@ impl Alpha {
             }
         }
 
-        Alpha::Inverse
+        if allow_inverse {
+            Alpha::Inverse
+        } else {
+            panic!("could not find a small positive exponent and allow_inverse was not enabled")
+        }
     }
 
     fn alpha_coprime_to_p_minus_one<F: PrimeField>(alpha: u32, p: F::BigInt) -> bool {
@@ -97,16 +101,16 @@ mod tests {
         // We know from the Poseidon paper that we should get an alpha of 5 for
         // BLS12-381 and BN254 (see Table 2)
         let p = FqParameters381::MODULUS;
-        assert_eq!(Alpha::generate::<Fq381>(p), Alpha::Exponent(5));
+        assert_eq!(Alpha::generate::<Fq381>(p, true), Alpha::Exponent(5));
 
         let p = FqParameters254::MODULUS;
-        assert_eq!(Alpha::generate::<Fq254>(p), Alpha::Exponent(5));
+        assert_eq!(Alpha::generate::<Fq254>(p, true), Alpha::Exponent(5));
     }
 
     #[test]
     fn check_alpha_17() {
         // For Poseidon377, we should get an alpha of 17 (from our own work).
         let p = FqParameters377::MODULUS;
-        assert_eq!(Alpha::generate::<Fq377>(p), Alpha::Exponent(17));
+        assert_eq!(Alpha::generate::<Fq377>(p, true), Alpha::Exponent(17));
     }
 }

--- a/poseidon-paramgen/src/input.rs
+++ b/poseidon-paramgen/src/input.rs
@@ -1,0 +1,36 @@
+use ark_ff::BigInteger;
+
+use crate::log2;
+
+/// Input parameters that are used to generate Poseidon parameters.
+#[derive(Clone)]
+pub struct InputParameters<T: BigInteger> {
+    /// Whether or not to allow inverse alpha.
+    pub allow_inverse: bool,
+
+    /// Security level in bits.
+    pub M: usize,
+
+    /// Width of desired hash function, e.g. $t=3$ corresponds to 2-to-1 hash.
+    pub t: usize,
+
+    /// Modulus of the prime field.
+    pub p: T, // let modulus = <F as PrimeField>::Params::MODULUS;
+
+    // The below are derived values, stored for convenience.
+    /// log_2(p)
+    pub log_2_p: f64,
+}
+
+impl<T: BigInteger> InputParameters<T> {
+    pub fn new(M: usize, t: usize, p: T, allow_inverse: bool) -> Self {
+        let log_2_p = log2(p);
+        InputParameters {
+            M,
+            t,
+            p,
+            log_2_p,
+            allow_inverse,
+        }
+    }
+}

--- a/poseidon-paramgen/src/matrix.rs
+++ b/poseidon-paramgen/src/matrix.rs
@@ -1,21 +1,41 @@
 use ark_ff::PrimeField;
 
 /// Represents a matrix over Fp
-pub struct Matrix<F: PrimeField>(pub Vec<F>);
+pub struct Matrix<F: PrimeField> {
+    pub elements: Vec<F>,
+    pub n_cols: usize,
+    pub n_rows: usize,
+}
+
+impl<F: PrimeField> Matrix<F> {
+    pub fn new(n_rows: usize, n_cols: usize, elements: Vec<F>) -> Matrix<F> {
+        if elements.len() != n_rows * n_cols {
+            panic!("Matrix has insufficient elements")
+        }
+        Matrix {
+            elements,
+            n_cols,
+            n_rows,
+        }
+    }
+
+    pub fn get_element(&self, i: usize, j: usize) -> F {
+        self.elements[i * self.n_cols + j]
+    }
+}
 
 /// Represents a square matrix over Fp
 pub struct SquareMatrix<F: PrimeField> {
-    pub elements: Matrix<F>,
-    pub dim: usize,
+    pub inner: Matrix<F>,
 }
 
 impl<F: PrimeField> SquareMatrix<F> {
     pub fn elements(&self) -> &Vec<F> {
-        &self.elements.0
+        &self.inner.elements
     }
 
     pub fn get_element(&self, i: usize, j: usize) -> F {
-        self.elements.0[i * self.dim + j]
+        self.inner.get_element(i, j)
     }
 
     pub fn from_vec(elements: Vec<F>) -> Self {
@@ -26,8 +46,7 @@ impl<F: PrimeField> SquareMatrix<F> {
         let dim = (elements.len() as f64).sqrt() as usize;
 
         SquareMatrix {
-            elements: Matrix(elements),
-            dim,
+            inner: Matrix::new(dim, dim, elements),
         }
     }
 
@@ -35,17 +54,9 @@ impl<F: PrimeField> SquareMatrix<F> {
         SquareMatrix::from_vec(vec![a, b, c, d])
     }
 
-    pub fn nrows(&self) -> usize {
-        self.dim
-    }
-
-    pub fn ncols(&self) -> usize {
-        self.dim
-    }
-
     /// Compute the matrix determinant
     pub fn determinant(&self) -> F {
-        match self.dim {
+        match self.inner.n_cols {
             0 => panic!("matrix has no elements!"),
             1 => self.get_element(0, 0),
             2 => {
@@ -75,15 +86,15 @@ impl<F: PrimeField> SquareMatrix<F> {
                 let mut det = F::zero();
                 let mut levi_civita = true;
 
-                for i in 0..self.dim {
+                for i in 0..self.inner.n_cols {
                     let mut elements: Vec<F> = Vec::new();
                     for k in 0..i {
-                        for l in 1..self.dim {
+                        for l in 1..self.inner.n_cols {
                             elements.push(self.get_element(k, l))
                         }
                     }
-                    for k in i + 1..self.dim {
-                        for l in 1..self.dim {
+                    for k in i + 1..self.inner.n_cols {
+                        for l in 1..self.inner.n_cols {
                             elements.push(self.get_element(k, l))
                         }
                     }

--- a/poseidon-paramgen/src/mds.rs
+++ b/poseidon-paramgen/src/mds.rs
@@ -19,6 +19,10 @@ where
         MdsMatrix::fixed_cauchy_matrix(&input)
     }
 
+    pub fn n_rows(&self) -> usize {
+        self.0.inner.n_rows
+    }
+
     /// Generate a deterministic Cauchy matrix
     ///
     /// The original Poseidon paper describes a method for constructing MDS matrices
@@ -66,11 +70,11 @@ mod tests {
         let M = 128;
         let t = 3;
 
-        let input = InputParameters::new(M, 3, Fq381Parameters::MODULUS);
+        let input = InputParameters::new(M, 3, Fq381Parameters::MODULUS, true);
         let MDS_matrix: MdsMatrix<Fq> = MdsMatrix::new(&input);
 
         assert!(MDS_matrix.0.determinant() != Fq::zero());
-        assert_eq!(MDS_matrix.0.nrows(), t);
+        assert_eq!(MDS_matrix.n_rows(), t);
         assert!(MDS_matrix.0.get_element(0, 0) != Fq::zero());
     }
 }

--- a/poseidon-paramgen/src/round_constants.rs
+++ b/poseidon-paramgen/src/round_constants.rs
@@ -1,0 +1,27 @@
+use ark_ff::PrimeField;
+use merlin::Transcript;
+
+use crate::{transcript::TranscriptProtocol, Alpha, InputParameters, Matrix, RoundNumbers};
+
+/// Represents an matrix of round constants.
+pub struct ArcMatrix<F: PrimeField>(pub Matrix<F>);
+
+impl<F> ArcMatrix<F>
+where
+    F: PrimeField,
+{
+    pub fn generate(
+        input: &InputParameters<F::BigInt>,
+        round_numbers: RoundNumbers,
+        alpha: Alpha,
+    ) -> ArcMatrix<F> {
+        let mut transcript = Transcript::new(b"round-constants");
+        transcript.domain_sep::<F>(input, round_numbers, alpha);
+
+        let num_total_rounds = round_numbers.total();
+        let elements = (0..num_total_rounds * input.t)
+            .map(|_| transcript.round_constant())
+            .collect();
+        ArcMatrix(Matrix::new(input.t, num_total_rounds, elements))
+    }
+}

--- a/poseidon-paramgen/src/rounds.rs
+++ b/poseidon-paramgen/src/rounds.rs
@@ -5,7 +5,7 @@ use ark_ff::BigInteger;
 use super::{Alpha, InputParameters};
 
 /// `RoundNumbers` based on the equations from the original Poseidon paper.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct RoundNumbers {
     /// Number of partial rounds.
     r_P: usize,

--- a/poseidon-paramgen/src/transcript.rs
+++ b/poseidon-paramgen/src/transcript.rs
@@ -1,26 +1,42 @@
 use ark_ff::{BigInteger, PrimeField};
 use merlin::Transcript;
 
-use crate::InputParameters;
+use crate::{Alpha, InputParameters, RoundNumbers};
 
 pub(crate) trait TranscriptProtocol {
-    fn domain_sep<F: PrimeField>(&mut self, input: &InputParameters<F::BigInt>);
-    fn cauchy_coefficient<F: PrimeField>(&mut self) -> F;
+    fn domain_sep<F: PrimeField>(
+        &mut self,
+        input: &InputParameters<F::BigInt>,
+        round_numbers: RoundNumbers,
+        alpha: Alpha,
+    );
+    fn round_constant<F: PrimeField>(&mut self) -> F;
 }
 
 impl TranscriptProtocol for Transcript {
-    fn domain_sep<F: PrimeField>(&mut self, input: &InputParameters<F::BigInt>) {
+    fn domain_sep<F: PrimeField>(
+        &mut self,
+        input: &InputParameters<F::BigInt>,
+        round_numbers: RoundNumbers,
+        alpha: Alpha,
+    ) {
         self.append_message(b"dom-sep", b"poseidon-paramgen");
         // Bind transcript to input parameter choices
         self.append_message(b"t", &input.t.to_le_bytes());
         self.append_message(b"M", &input.M.to_le_bytes());
         self.append_message(b"p", &input.p.to_bytes_le());
+
+        // Bind transcript also to specific instance as done with the Grain LFSR
+        // in Appendix F of the Poseidon paper.
+        self.append_message(b"r_F", &[round_numbers.full() as u8]);
+        self.append_message(b"r_P", &[round_numbers.partial() as u8]);
+        self.append_message(b"alpha", &alpha.to_bytes_le());
     }
 
-    fn cauchy_coefficient<F: PrimeField>(&mut self) -> F {
+    fn round_constant<F: PrimeField>(&mut self) -> F {
         let size_in_bytes = (F::size_in_bits() + 128) / 8;
         let mut dest = vec![0u8; size_in_bytes];
-        self.challenge_bytes(b"cauchy-coefficient", &mut dest);
+        self.challenge_bytes(b"round-constant", &mut dest);
         F::from_le_bytes_mod_order(&dest)
     }
 }

--- a/poseidon-paramgen/tests/appendix_g.rs
+++ b/poseidon-paramgen/tests/appendix_g.rs
@@ -79,7 +79,7 @@ mod tests {
                 r_P: row[5],
                 cost: row[6],
             };
-            let input = InputParameters::new(table_row.M, table_row.t, table_row.p);
+            let input = InputParameters::new(table_row.M, table_row.t, table_row.p, true);
             let rounds = RoundNumbers::new(&input, &alpha);
             assert_eq!(rounds.full(), table_row.r_F);
             assert_eq!(rounds.partial(), table_row.r_P);
@@ -131,7 +131,7 @@ mod tests {
                 cost: row[6],
             };
 
-            let input = InputParameters::new(table_row.M, table_row.t, table_row.p);
+            let input = InputParameters::new(table_row.M, table_row.t, table_row.p, true);
             let rounds = RoundNumbers::new(&input, &alpha);
             assert_eq!(rounds.full(), table_row.r_F);
             assert_eq!(rounds.partial(), table_row.r_P);
@@ -182,7 +182,7 @@ mod tests {
                 r_P: row[5],
                 cost: row[6],
             };
-            let input = InputParameters::new(table_row.M, table_row.t, table_row.p);
+            let input = InputParameters::new(table_row.M, table_row.t, table_row.p, true);
             let rounds = RoundNumbers::new(&input, &alpha);
             assert_eq!(rounds.full(), table_row.r_F);
             assert_eq!(rounds.partial(), table_row.r_P);
@@ -194,25 +194,25 @@ mod tests {
         let alpha = Alpha::Exponent(17);
 
         // $t=3$ corresponds to a 2:1 hash
-        let input = InputParameters::new(128, 3, Fq377Parameters::MODULUS);
+        let input = InputParameters::new(128, 3, Fq377Parameters::MODULUS, true);
         let rounds = RoundNumbers::new(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
 
         // $t=4$ corresponds to a 3:1 hash
-        let input = InputParameters::new(128, 4, Fq377Parameters::MODULUS);
+        let input = InputParameters::new(128, 4, Fq377Parameters::MODULUS, true);
         let rounds = RoundNumbers::new(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
 
         // $t=5$ corresponds to a 4:1 hash
-        let input = InputParameters::new(128, 5, Fq377Parameters::MODULUS);
+        let input = InputParameters::new(128, 5, Fq377Parameters::MODULUS, true);
         let rounds = RoundNumbers::new(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
 
         // $t=6$ corresponds to a 5:1 hash
-        let input = InputParameters::new(128, 6, Fq377Parameters::MODULUS);
+        let input = InputParameters::new(128, 6, Fq377Parameters::MODULUS, true);
         let rounds = RoundNumbers::new(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);


### PR DESCRIPTION
Closes #8

also:
* allows user to toggle whether or not they want to allow inverse alpha
* binds the transcript RNG to the specific Poseidon instance (in addition to user-selected input parameters) as done in Appendix F of the paper