### PR TITLE
perf: speeding up `poseidon-permutation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "poseidon-paramgen",
     "poseidon-permutation",
 ]
+
+[profile.release]
+debug = true

--- a/poseidon-paramgen/src/lib.rs
+++ b/poseidon-paramgen/src/lib.rs
@@ -26,7 +26,9 @@ mod utils;
 
 pub use alpha::Alpha;
 pub use input::InputParameters;
-pub use matrix::{mat_mul, Matrix, MatrixOperations, SquareMatrix, SquareMatrixOperations};
+pub use matrix::{
+    dot_product, mat_mul, Matrix, MatrixOperations, SquareMatrix, SquareMatrixOperations,
+};
 pub use mds::{MdsMatrix, OptimizedMdsMatrices};
 pub use round_constants::{ArcMatrix, OptimizedArcMatrix};
 pub use rounds::RoundNumbers;

--- a/poseidon-paramgen/src/matrix.rs
+++ b/poseidon-paramgen/src/matrix.rs
@@ -15,7 +15,7 @@ mod square;
 mod traits;
 
 pub use base::Matrix;
-pub use mult::mat_mul;
+pub use mult::{dot_product, mat_mul};
 pub use square::SquareMatrix;
 pub use traits::{MatrixOperations, SquareMatrixOperations};
 

--- a/poseidon-paramgen/src/matrix/mult.rs
+++ b/poseidon-paramgen/src/matrix/mult.rs
@@ -11,7 +11,7 @@ fn flatten<T>(nested: Vec<Vec<T>>) -> Vec<T> {
 }
 
 /// Compute vector dot product
-pub fn dot_product<F: PrimeField>(a: Vec<F>, b: Vec<F>) -> F {
+pub fn dot_product<F: PrimeField>(a: &[F], b: &[F]) -> F {
     if a.len() != b.len() {
         panic!("vecs not same len")
     }
@@ -30,14 +30,12 @@ pub fn mat_mul<F: PrimeField, M: MatrixOperations<F>>(lhs: &M, rhs: &M) -> Resul
     let rhs_T = rhs.transpose();
 
     let res: Vec<Vec<F>> = lhs
-        .rows()
-        .into_iter()
+        .iter_rows()
         .map(|row| {
             // Rows of the transposed matrix are the columns of the original matrix
             rhs_T
-                .rows()
-                .into_iter()
-                .map(|column| dot_product(row.to_vec(), column.to_vec()))
+                .iter_rows()
+                .map(|column| dot_product(row, column))
                 .collect()
         })
         .collect();

--- a/poseidon-paramgen/src/matrix/mult.rs
+++ b/poseidon-paramgen/src/matrix/mult.rs
@@ -5,11 +5,6 @@ use ark_ff::PrimeField;
 
 use crate::{Matrix, MatrixOperations, SquareMatrix};
 
-/// Flatten a vec of vecs
-fn flatten<T>(nested: Vec<Vec<T>>) -> Vec<T> {
-    nested.into_iter().flatten().collect()
-}
-
 /// Compute vector dot product
 pub fn dot_product<F: PrimeField>(a: &[F], b: &[F]) -> F {
     if a.len() != b.len() {
@@ -29,18 +24,19 @@ pub fn mat_mul<F: PrimeField, M: MatrixOperations<F>>(lhs: &M, rhs: &M) -> Resul
 
     let rhs_T = rhs.transpose();
 
-    let res: Vec<Vec<F>> = lhs
-        .iter_rows()
-        .map(|row| {
-            // Rows of the transposed matrix are the columns of the original matrix
-            rhs_T
-                .iter_rows()
-                .map(|column| dot_product(row, column))
-                .collect()
-        })
-        .collect();
-
-    Ok(M::new(lhs.n_rows(), rhs.n_cols(), flatten(res)))
+    Ok(M::new(
+        lhs.n_rows(),
+        rhs.n_cols(),
+        lhs.iter_rows()
+            .flat_map(|row| {
+                // Rows of the transposed matrix are the columns of the original matrix
+                rhs_T
+                    .iter_rows()
+                    .map(|column| dot_product(row, column))
+                    .collect::<Vec<F>>()
+            })
+            .collect(),
+    ))
 }
 
 /// Multiply scalar by Matrix

--- a/poseidon-paramgen/src/matrix/traits.rs
+++ b/poseidon-paramgen/src/matrix/traits.rs
@@ -1,3 +1,5 @@
+use std::slice::Chunks;
+
 use anyhow::Result;
 
 /// Basic matrix operations all matrices should implement.
@@ -12,6 +14,10 @@ pub trait MatrixOperations<F> {
     fn set_element(&mut self, i: usize, j: usize, val: F);
     /// Get rows
     fn rows(&self) -> Vec<&[F]>;
+    /// Get rows in chunks
+    fn iter_rows(&self) -> Chunks<F> {
+        self.elements().chunks(self.n_cols())
+    }
     /// Compute matrix transpose
     fn transpose(&self) -> Self;
     /// Compute Hadamard (element-wise) product

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -26,6 +26,3 @@ rand_chacha = "0.3"
 [[bench]]
 name = "permutation"
 harness = false
-
-[profile.release]
-debug = true

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -18,6 +18,7 @@ ark-ed-on-bls12-377 = "0.3"
 num-bigint = "0.4"
 ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "split-sponge" }
 criterion = { version = "0.3", features=["html_reports"] }
+once_cell = "1.8"
 proptest = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
@@ -25,3 +26,6 @@ rand_chacha = "0.3"
 [[bench]]
 name = "permutation"
 harness = false
+
+[profile.release]
+debug = true

--- a/poseidon-permutation/benches/permutation.rs
+++ b/poseidon-permutation/benches/permutation.rs
@@ -161,7 +161,7 @@ pub fn bench_unoptimized_vs_optimized(c: &mut Criterion) {
     group.finish();
 }
 
-//criterion_group!(benches, bench_ark_sponge_vs_optimized);
-criterion_group!(benches, bench_ark_sponge_vs_unoptimized);
+criterion_group!(benches, bench_ark_sponge_vs_optimized);
+//criterion_group!(benches, bench_ark_sponge_vs_unoptimized);
 //criterion_group!(benches, bench_unoptimized_vs_optimized);
 criterion_main!(benches);

--- a/poseidon-permutation/benches/permutation.rs
+++ b/poseidon-permutation/benches/permutation.rs
@@ -2,16 +2,18 @@ use ark_ed_on_bls12_377::{Fq, FqParameters};
 use ark_ff::{FpParameters, PrimeField};
 use ark_sponge::poseidon::{Parameters, State};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use once_cell::sync::Lazy;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
 
 use poseidon_paramgen::PoseidonParameters;
 use poseidon_permutation::Instance;
 
-fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let params_4_to_1 = PoseidonParameters::<Fq>::new(128, 5, FqParameters::MODULUS, true);
+static PARAMS_4_TO_1: Lazy<PoseidonParameters<Fq>> =
+    Lazy::new(|| PoseidonParameters::<Fq>::new(128, 5, FqParameters::MODULUS, true));
 
-    let params_ark: Parameters<Fq> = params_4_to_1.into();
+fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
+    let params_ark: Parameters<Fq> = (PARAMS_4_TO_1.clone()).into();
     let mut ark_state = State::from(params_ark);
     ark_state[0] = *i;
     ark_state[1] = *j;
@@ -24,13 +26,17 @@ fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
 }
 
 fn hash_4_1_our_impl(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let params_4_to_1 = PoseidonParameters::<Fq>::new(128, 5, FqParameters::MODULUS, true);
-    let mut our_instance = Instance::new(params_4_to_1);
+    let mut our_instance = Instance::new(PARAMS_4_TO_1.clone());
     our_instance.n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
 }
 
+fn hash_4_1_our_impl_unoptimized(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
+    let mut our_instance = Instance::new(PARAMS_4_TO_1.clone());
+    our_instance.unoptimized_n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
+}
+
 pub fn bench_ark_sponge_vs_optimized(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ark_sponge_vs_unoptimized");
+    let mut group = c.benchmark_group("ark_sponge_vs_optimized");
     let n = 10;
     let mut rng = ChaChaRng::seed_from_u64(666);
     let mut test_field_elements = Vec::with_capacity(n);
@@ -55,16 +61,16 @@ pub fn bench_ark_sponge_vs_optimized(c: &mut Criterion) {
         ))
     }
 
-    for (i, j, k, l, m) in test_field_elements {
+    for (index, (i, j, k, l, m)) in test_field_elements.iter().enumerate() {
         group.bench_with_input(
-            BenchmarkId::new("ark-sponge", format!("ark-sponge:{}", i)),
+            BenchmarkId::new("ark-sponge", format!("ark-sponge: {}", index)),
             &(&i, &j, &k, &l, &m),
             |b, (i, j, k, l, m)| b.iter(|| hash_4_1_ark_sponge(i, j, k, l, m)),
         );
         group.bench_with_input(
             BenchmarkId::new(
                 "poseidon-permutation",
-                format!("poseidon-permutation:{}", i),
+                format!("poseidon-permutation: {}", index),
             ),
             &(&i, &j, &k, &l, &m),
             |b, (i, j, k, l, m)| b.iter(|| hash_4_1_our_impl(i, j, k, l, m)),
@@ -73,5 +79,47 @@ pub fn bench_ark_sponge_vs_optimized(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_ark_sponge_vs_optimized);
+pub fn bench_unoptimized_vs_optimized(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unoptimized_vs_optimized");
+    let n = 10;
+    let mut rng = ChaChaRng::seed_from_u64(666);
+    let mut test_field_elements = Vec::with_capacity(n);
+
+    for _ in 0..n {
+        let mut i_bytes = [0u8; 32];
+        let mut j_bytes = [0u8; 32];
+        let mut k_bytes = [0u8; 32];
+        let mut l_bytes = [0u8; 32];
+        let mut m_bytes = [0u8; 32];
+        rng.fill_bytes(&mut i_bytes);
+        rng.fill_bytes(&mut j_bytes);
+        rng.fill_bytes(&mut k_bytes);
+        rng.fill_bytes(&mut l_bytes);
+        rng.fill_bytes(&mut m_bytes);
+        test_field_elements.push((
+            Fq::from_le_bytes_mod_order(&i_bytes[..]),
+            Fq::from_le_bytes_mod_order(&j_bytes[..]),
+            Fq::from_le_bytes_mod_order(&k_bytes[..]),
+            Fq::from_le_bytes_mod_order(&l_bytes[..]),
+            Fq::from_le_bytes_mod_order(&m_bytes[..]),
+        ))
+    }
+
+    for (index, (i, j, k, l, m)) in test_field_elements.iter().enumerate() {
+        group.bench_with_input(
+            BenchmarkId::new("base_alg", format!("base_alg: {}", index)),
+            &(&i, &j, &k, &l, &m),
+            |b, (i, j, k, l, m)| b.iter(|| hash_4_1_our_impl_unoptimized(i, j, k, l, m)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("optimized_alg", format!("optimized_alg: {}", index)),
+            &(&i, &j, &k, &l, &m),
+            |b, (i, j, k, l, m)| b.iter(|| hash_4_1_our_impl(i, j, k, l, m)),
+        );
+    }
+    group.finish();
+}
+
+//criterion_group!(benches, bench_ark_sponge_vs_optimized);
+criterion_group!(benches, bench_unoptimized_vs_optimized);
 criterion_main!(benches);


### PR DESCRIPTION
This PR contains some performance fixes in the implementation of `poseidon-permutation`. Below are some numbers based on benchmarking and profiling. Related to https://github.com/penumbra-zone/penumbra/issues/1123.

From the paper the optimized version of Poseidon reduces the number of multiplications in the partial rounds. 

The approximate "5x" number cited in the paper came from a Poseidon instance with t=4, R_F = 8, R_P = 42, so the number of multiplications per permutation was:
t^2 (R_F + R_P) = 24^2 * (8 + 42) = 28,800 multiplications
After the optimization, the number of multiplications in the partial rounds goes from t^2 to 2*t, so after:
t^2 * R_F + 2 * t R_P = 24^2 * 8 + 2 * 24 * 42 = 6,624 multiplications
Which is about a 4.3x reduction in multiplications in the permutation. There are big gains here because the instance is very high t, very high R_F (partial round).

For us testing with the highest width hash we use, 4:1, we have t=5, R_F = 8, R_P = 31 so for us the expected reduction in the number of multiplications:
Before: t^2 (R_F + R_P) = 5^2 * (8 + 31) = 975 multiplications
After: t^2 * R_F + 2 * t R_P = 5^2 * 8 + 5 * 2 * 31 = 510 multiplications
Which is about a 1.9x reduction in multiplications. 

Comparing the empirical performance for the 4:1 parameter set derived using `poseidon-paramgen`:
`ark-sponge`: ~39.5us/hash
unoptimized `poseidon-permutation` (this repo): ~36.0us/hash
optimized `poseidon-permutation` (this repo): ~26.8us/hash

At this point from profiling the computation for the optimized permutation, we're dominated by applying the Sboxes, which take about 60% of the computation of the permutation. The partial round multiplication is down to 26%, so if further improvements are made to that area of the code we'll get some additional speedups. 
