### PR TITLE
perf: don't use const with once_cell

### DIFF
--- a/poseidon-permutation/benches/permutation.rs
+++ b/poseidon-permutation/benches/permutation.rs
@@ -26,12 +26,12 @@ fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
 }
 
 fn hash_4_1_our_impl(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let mut our_instance = Instance::new(PARAMS_4_TO_1.clone());
+    let mut our_instance = Instance::new(&PARAMS_4_TO_1);
     our_instance.n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
 }
 
 fn hash_4_1_our_impl_unoptimized(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let mut our_instance = Instance::new(PARAMS_4_TO_1.clone());
+    let mut our_instance = Instance::new(&PARAMS_4_TO_1);
     our_instance.unoptimized_n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
 }
 

--- a/poseidon-permutation/src/permutation.rs
+++ b/poseidon-permutation/src/permutation.rs
@@ -7,17 +7,17 @@ use poseidon_paramgen::{Alpha, MatrixOperations, PoseidonParameters};
 /// Represents a generic instance of `Poseidon`.
 ///
 /// Intended for generic fixed-width hashing.
-pub struct Instance<F: PrimeField> {
+pub struct Instance<'a, F: PrimeField> {
     /// Parameters for this instance of Poseidon.
-    parameters: PoseidonParameters<F>,
+    parameters: &'a PoseidonParameters<F>,
 
     /// Inner state.
     state_words: Vec<F>,
 }
 
-impl<F: PrimeField> Instance<F> {
+impl<'a, F: PrimeField> Instance<'a, F> {
     /// Instantiate a new hash function over GF(p) given `Parameters`.
-    pub fn new(parameters: PoseidonParameters<F>) -> Self {
+    pub fn new(parameters: &'a PoseidonParameters<F>) -> Self {
         let t = parameters.t;
         Self {
             parameters,
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn check_optimized_impl_vs_sage() {
         let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
-        let mut our_instance = Instance::new(params_2_to_1);
+        let mut our_instance = Instance::new(&params_2_to_1);
         let hash_output =
             our_instance.n_to_1_fixed_hash(vec![Fq::zero(), Fq::from(1u64), Fq::from(2u64)]);
         let output_words = our_instance.output_words();
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn check_unoptimized_impl_vs_sage() {
         let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
-        let mut our_instance = Instance::new(params_2_to_1);
+        let mut our_instance = Instance::new(&params_2_to_1);
         let hash_output = our_instance.unoptimized_n_to_1_fixed_hash(vec![
             Fq::zero(),
             Fq::from(1u64),
@@ -348,7 +348,7 @@ mod tests {
             ark_state.permute();
             let ark_result = ark_state[1];
 
-            let mut our_instance = Instance::new(params_4_to_1);
+            let mut our_instance = Instance::new(&params_4_to_1);
             let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
 
             assert_eq!(ark_result, our_result);
@@ -359,10 +359,10 @@ mod tests {
             let t = 5;
             let params_4_to_1 = PoseidonParameters::<Fq>::new(128, t, FqParameters::MODULUS, true);
 
-            let mut our_instance = Instance::new(params_4_to_1.clone());
+            let mut our_instance = Instance::new(&params_4_to_1);
             let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
 
-            let mut unoptimized_instance = Instance::new(params_4_to_1);
+            let mut unoptimized_instance = Instance::new(&params_4_to_1);
             let unoptimized_result =
                 unoptimized_instance.unoptimized_n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
 

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -20,3 +20,10 @@ num-bigint = "0.4.3"
 [dev-dependencies]
 ark-ed-on-bls12-381 = "0.3"
 proptest = "1"
+criterion = { version = "0.3", features=["html_reports"] }
+rand_core = { version = "0.6.3", features = ["getrandom"] }
+rand_chacha = "0.3"
+
+[[bench]]
+name = "oldhash"
+harness = false

--- a/poseidon377/benches/oldhash.rs
+++ b/poseidon377/benches/oldhash.rs
@@ -1,0 +1,73 @@
+use ark_ed_on_bls12_377::Fq;
+use ark_ff::PrimeField;
+use ark_sponge::poseidon::State;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand_chacha::ChaChaRng;
+use rand_core::{RngCore, SeedableRng};
+
+use poseidon377::{hash_4, params};
+
+fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
+    let mut state = State::from(params::rate_4());
+
+    // Use the domain separator as the sponge's capacity element
+    state[0] = *i;
+    state[1] = *j;
+    state[2] = *k;
+    state[3] = *l;
+    state[4] = *m;
+
+    state.permute();
+    state[1]
+}
+
+fn hash_4_1_our_impl(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
+    hash_4(i, (*j, *k, *l, *m))
+}
+
+pub fn poseidon377_ark_sponge_vs_optimized(c: &mut Criterion) {
+    let mut group = c.benchmark_group("poseidon377_ark_sponge_vs_optimized");
+    let n = 10;
+    let mut rng = ChaChaRng::seed_from_u64(666);
+    let mut test_field_elements = Vec::with_capacity(n);
+
+    for _ in 0..n {
+        let mut i_bytes = [0u8; 32];
+        let mut j_bytes = [0u8; 32];
+        let mut k_bytes = [0u8; 32];
+        let mut l_bytes = [0u8; 32];
+        let mut m_bytes = [0u8; 32];
+        rng.fill_bytes(&mut i_bytes);
+        rng.fill_bytes(&mut j_bytes);
+        rng.fill_bytes(&mut k_bytes);
+        rng.fill_bytes(&mut l_bytes);
+        rng.fill_bytes(&mut m_bytes);
+        test_field_elements.push((
+            Fq::from_le_bytes_mod_order(&i_bytes[..]),
+            Fq::from_le_bytes_mod_order(&j_bytes[..]),
+            Fq::from_le_bytes_mod_order(&k_bytes[..]),
+            Fq::from_le_bytes_mod_order(&l_bytes[..]),
+            Fq::from_le_bytes_mod_order(&m_bytes[..]),
+        ))
+    }
+
+    for (index, (i, j, k, l, m)) in test_field_elements.iter().enumerate() {
+        group.bench_with_input(
+            BenchmarkId::new("ark-sponge", format!("ark-sponge: {}", index)),
+            &(&i, &j, &k, &l, &m),
+            |b, (i, j, k, l, m)| b.iter(|| hash_4_1_ark_sponge(i, j, k, l, m)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new(
+                "poseidon-permutation",
+                format!("poseidon-permutation: {}", index),
+            ),
+            &(&i, &j, &k, &l, &m),
+            |b, (i, j, k, l, m)| b.iter(|| hash_4_1_our_impl(i, j, k, l, m)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, poseidon377_ark_sponge_vs_optimized);
+criterion_main!(benches);

--- a/poseidon377/src/hash.rs
+++ b/poseidon377/src/hash.rs
@@ -2,25 +2,29 @@ use crate::{Fq, Instance};
 
 /// Hash a single [`Fq`] element with the provided `domain_separator`.
 pub fn hash_1(domain_separator: &Fq, value: Fq) -> Fq {
-    let mut state = Instance::new(crate::RATE_1_PARAMS.clone());
+    let params = &crate::RATE_1_PARAMS;
+    let mut state = Instance::new(params);
     state.n_to_1_fixed_hash(vec![domain_separator.clone(), value])
 }
 
 /// Hash two [`Fq`] elements with the provided `domain_separator`.
 pub fn hash_2(domain_separator: &Fq, value: (Fq, Fq)) -> Fq {
-    let mut state = Instance::new(crate::RATE_2_PARAMS.clone());
+    let params = &crate::RATE_2_PARAMS;
+    let mut state = Instance::new(params);
     state.n_to_1_fixed_hash(vec![domain_separator.clone(), value.0, value.1])
 }
 
 /// Hash three [`Fq`] elements with the provided `domain_separator`.
 pub fn hash_3(domain_separator: &Fq, value: (Fq, Fq, Fq)) -> Fq {
-    let mut state = Instance::new(crate::RATE_3_PARAMS.clone());
+    let params = &crate::RATE_3_PARAMS;
+    let mut state = Instance::new(params);
     state.n_to_1_fixed_hash(vec![domain_separator.clone(), value.0, value.1, value.2])
 }
 
 /// Hash four [`Fq`] elements with the provided `domain_separator`.
 pub fn hash_4(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq)) -> Fq {
-    let mut state = Instance::new(crate::RATE_4_PARAMS.clone());
+    let params = &crate::RATE_4_PARAMS;
+    let mut state = Instance::new(&params);
     state.n_to_1_fixed_hash(vec![
         domain_separator.clone(),
         value.0,
@@ -32,7 +36,8 @@ pub fn hash_4(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq)) -> Fq {
 
 /// Hash five [`Fq`] elements with the provided `domain_separator`.
 pub fn hash_5(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq, Fq)) -> Fq {
-    let mut state = Instance::new(crate::RATE_5_PARAMS.clone());
+    let params = &crate::RATE_5_PARAMS;
+    let mut state = Instance::new(params);
     state.n_to_1_fixed_hash(vec![
         domain_separator.clone(),
         value.0,

--- a/poseidon377/src/lib.rs
+++ b/poseidon377/src/lib.rs
@@ -3,7 +3,7 @@
 use once_cell::sync::Lazy;
 
 mod hash;
-mod params;
+pub mod params;
 /// Module containing optimized parameters. Temporary until we are ready
 /// to make the next round of address-breaking changes.
 mod temp_params;
@@ -11,15 +11,15 @@ mod temp_params;
 pub use hash::{hash_1, hash_2, hash_3, hash_4, hash_5};
 
 /// Parameters for the rate-1 instance of Poseidon.
-pub const RATE_1_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(temp_params::rate_1);
+pub static RATE_1_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(|| temp_params::rate_1());
 /// Parameters for the rate-2 instance of Poseidon.
-pub const RATE_2_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(temp_params::rate_2);
+pub static RATE_2_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(|| temp_params::rate_2());
 /// Parameters for the rate-3 instance of Poseidon.
-pub const RATE_3_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(temp_params::rate_3);
+pub static RATE_3_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(|| temp_params::rate_3());
 /// Parameters for the rate-4 instance of Poseidon.
-pub const RATE_4_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(temp_params::rate_4);
+pub static RATE_4_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(|| temp_params::rate_4());
 /// Parameters for the rate-5 instance of Poseidon.
-pub const RATE_5_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(temp_params::rate_5);
+pub static RATE_5_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(|| temp_params::rate_5());
 
 pub use ark_ed_on_bls12_377::Fq;
 pub use poseidon_paramgen::PoseidonParameters;


### PR DESCRIPTION
I profiled the `hash_4` function in `poseidon377` -- previously (in #21) I had focused on profiling the `permute` method where I had assumed 99% of the computation would be happening -- and it appears we've been using `once_cell` wrong in this repo. The docs state that using `const` for the `Lazy` variable will compile however it "works wrong" - instead `static` must be used. In our case this meant that every time we accessed the parameters struct, we were actually creating it all over again, resulting in a ton of wasted computation. 

tl;dr This means I think that the speedup should not be not 30% as reported in #21 but closer to 30X - from testing on my M1 it's about 615us before vs 22us after (per hash)