### PR TITLE
add rate 7 poseidon hash

### DIFF
--- a/poseidon377/build.rs
+++ b/poseidon377/build.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let security_level = 128;
     // Recall t = rate + capacity, so t=2 is rate=1, capacity=1 (i.e. 1:1 hash)
-    let t_values = vec![2, 3, 4, 5, 6, 7];
+    let t_values = vec![2, 3, 4, 5, 6, 7, 8];
     let params_codegen =
         poseidon_build::compile::<Fq>(security_level, t_values, FqParameters::MODULUS, true);
 

--- a/poseidon377/src/hash.rs
+++ b/poseidon377/src/hash.rs
@@ -63,6 +63,22 @@ pub fn hash_6(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq, Fq, Fq)) -> Fq {
     ])
 }
 
+/// Hash seven [`Fq`] elements with the provided `domain_separator`.
+pub fn hash_7(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq, Fq, Fq, Fq)) -> Fq {
+    let params = &crate::RATE_7_PARAMS;
+    let mut state = Instance::new(params);
+    state.n_to_1_fixed_hash(vec![
+        domain_separator.clone(),
+        value.0,
+        value.1,
+        value.2,
+        value.3,
+        value.4,
+        value.5,
+        value.6,
+    ])
+}
+
 #[cfg(test)]
 mod test {
     use ark_ff::PrimeField;

--- a/poseidon377/src/lib.rs
+++ b/poseidon377/src/lib.rs
@@ -7,7 +7,7 @@ mod params {
     include!(concat!(env!("OUT_DIR"), "/params.rs"));
 }
 
-pub use hash::{hash_1, hash_2, hash_3, hash_4, hash_5, hash_6};
+pub use hash::{hash_1, hash_2, hash_3, hash_4, hash_5, hash_6, hash_7};
 
 /// Parameters for the rate-1 instance of Poseidon.
 pub static RATE_1_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_1);
@@ -21,6 +21,8 @@ pub static RATE_4_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_
 pub static RATE_5_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_5);
 /// Parameters for the rate-6 instance of Poseidon.
 pub static RATE_6_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_6);
+/// Parameters for the rate-7 instance of Poseidon.
+pub static RATE_7_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_7);
 
 pub use ark_ed_on_bls12_377::Fq;
 pub use poseidon_paramgen::PoseidonParameters;


### PR DESCRIPTION
This PR adds a rate 7 poseidon hash to the poseidon377 crate in advance of https://github.com/penumbra-zone/penumbra/issues/1622 