### PR TITLE
feat: gadgets for poseidon in r1cs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
   fmt:
     name: Rustfmt

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "split-sponge" }
+ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 ark-ff = "0.3"
 merlin = "3.0"
 num = "0.4"

--- a/poseidon-paramgen/src/lib.rs
+++ b/poseidon-paramgen/src/lib.rs
@@ -38,7 +38,7 @@ pub use rounds::RoundNumbers;
 pub use utils::log2;
 
 use ark_ff::PrimeField;
-use ark_sponge::poseidon::Parameters as ArkPoseidonParameters;
+use ark_sponge::poseidon::PoseidonParameters as ArkPoseidonParameters;
 
 /// A set of Poseidon parameters for a given set of input parameters.
 #[derive(Clone, Debug)]
@@ -107,10 +107,12 @@ impl<F: PrimeField> Into<ArkPoseidonParameters<F>> for PoseidonParameters<F> {
         // TODO: let user specify different capacity choices
         let capacity = 1;
         let rate = self.t - capacity;
+        let full_rounds = self.rounds.full();
+        let partial_rounds = self.rounds.partial();
 
         ArkPoseidonParameters {
-            full_rounds: self.rounds.full(),
-            partial_rounds: self.rounds.partial(),
+            full_rounds,
+            partial_rounds,
             alpha,
             ark: self.arc.into(),
             mds: self.mds.into(),

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -16,7 +16,7 @@ poseidon-paramgen = { path = "../poseidon-paramgen/" }
 [dev-dependencies]
 ark-ed-on-bls12-377 = "0.3"
 num-bigint = "0.4"
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "split-sponge" }
+ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 criterion = { version = "0.3", features=["html_reports"] }
 once_cell = "1.8"
 proptest = "1"

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -15,9 +15,11 @@ poseidon-paramgen = { path= "../poseidon-paramgen" }
 poseidon-permutation = { path= "../poseidon-permutation" }
 ark-relations = { version="0.3", optional=true }
 ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-ark-ed-on-bls12-377 = { version = "0.3", features = ["r1cs"] }
+decaf377 = {  git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
 num-bigint = "0.4.3"
 ark-groth16 = { version = "0.3", optional=true }
+ark-snark = { version = "0.3", optional=true }
+ark-r1cs-std = {version = "0.3", optional=true }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = "0.3"
@@ -28,7 +30,7 @@ rand_chacha = "0.3"
 
 [features]
 default = []
-r1cs = ["ark-groth16", "ark-relations"]
+r1cs = ["ark-groth16", "ark-relations", "ark-snark", "ark-r1cs-std"]
 
 [[bench]]
 name = "oldhash"
@@ -38,3 +40,7 @@ harness = false
 poseidon-paramgen = { path = "../poseidon-paramgen/" }
 ark-ed-on-bls12-377 = "0.3"
 ark-ff = "0.3"
+
+[[test]]
+name = "r1cs"
+required-features = ["r1cs"]

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -13,9 +13,11 @@ once_cell = "1.8"
 ark-ff = "0.3"
 poseidon-paramgen = { path= "../poseidon-paramgen" }
 poseidon-permutation = { path= "../poseidon-permutation" }
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "split-sponge" }
-ark-ed-on-bls12-377 = "0.3"
+ark-relations = { version="0.3", optional=true }
+ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+ark-ed-on-bls12-377 = { version = "0.3", features = ["r1cs"] }
 num-bigint = "0.4.3"
+ark-groth16 = { version = "0.3", optional=true }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = "0.3"
@@ -23,6 +25,10 @@ proptest = "1"
 criterion = { version = "0.3", features=["html_reports"] }
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
+
+[features]
+default = []
+r1cs = ["ark-groth16", "ark-relations"]
 
 [[bench]]
 name = "oldhash"

--- a/poseidon377/benches/oldhash.rs
+++ b/poseidon377/benches/oldhash.rs
@@ -1,10 +1,10 @@
-use ark_ed_on_bls12_377::Fq;
 use ark_ff::PrimeField;
 use ark_sponge::{
     poseidon::{PoseidonParameters, PoseidonSponge},
     CryptographicSponge,
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use decaf377::Fq;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
 

--- a/poseidon377/src/lib.rs
+++ b/poseidon377/src/lib.rs
@@ -24,7 +24,7 @@ pub static RATE_6_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_
 /// Parameters for the rate-7 instance of Poseidon.
 pub static RATE_7_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_7);
 
-pub use ark_ed_on_bls12_377::Fq;
+pub use decaf377::Fq;
 pub use poseidon_paramgen::PoseidonParameters;
 pub use poseidon_permutation::Instance;
 

--- a/poseidon377/src/lib.rs
+++ b/poseidon377/src/lib.rs
@@ -27,3 +27,6 @@ pub static RATE_7_PARAMS: Lazy<PoseidonParameters<Fq>> = Lazy::new(params::rate_
 pub use ark_ed_on_bls12_377::Fq;
 pub use poseidon_paramgen::PoseidonParameters;
 pub use poseidon_permutation::Instance;
+
+#[cfg(feature = "r1cs")]
+pub mod r1cs;

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -1,0 +1,14 @@
+use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+use ark_sponge::{constraints::CryptographicSpongeVar, poseidon::constraints::PoseidonSpongeVar};
+
+use ark_ed_on_bls12_377::constraints::FqVar;
+
+use crate::Fq;
+
+pub fn hash_1(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: FqVar,
+) -> Result<FqVar, SynthesisError> {
+    todo!()
+}

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -10,5 +10,11 @@ pub fn hash_1(
     domain_separator: &FqVar,
     value: FqVar,
 ) -> Result<FqVar, SynthesisError> {
-    todo!()
+    let params = (*crate::RATE_1_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![domain_separator, &value])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
 }

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -1,7 +1,7 @@
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_sponge::{constraints::CryptographicSpongeVar, poseidon::constraints::PoseidonSpongeVar};
 
-use ark_ed_on_bls12_377::constraints::FqVar;
+use decaf377::r1cs::FqVar;
 
 use crate::Fq;
 

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -109,3 +109,26 @@ pub fn hash_6(
     let output = poseidon_instance.squeeze_field_elements(1)?;
     Ok(output[0].clone())
 }
+
+pub fn hash_7(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar, FqVar, FqVar, FqVar, FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_7_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![
+        domain_separator,
+        &value.0,
+        &value.1,
+        &value.2,
+        &value.3,
+        &value.4,
+        &value.5,
+        &value.6,
+    ])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -18,3 +18,94 @@ pub fn hash_1(
     let output = poseidon_instance.squeeze_field_elements(1)?;
     Ok(output[0].clone())
 }
+
+pub fn hash_2(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_2_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![domain_separator, &value.0, &value.1])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}
+
+pub fn hash_3(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_3_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![domain_separator, &value.0, &value.1, &value.2])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}
+
+pub fn hash_4(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar, FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_4_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![
+        domain_separator,
+        &value.0,
+        &value.1,
+        &value.2,
+        &value.3,
+    ])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}
+
+pub fn hash_5(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar, FqVar, FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_5_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![
+        domain_separator,
+        &value.0,
+        &value.1,
+        &value.2,
+        &value.3,
+        &value.4,
+    ])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}
+
+pub fn hash_6(
+    cs: ConstraintSystemRef<Fq>,
+    domain_separator: &FqVar,
+    value: (FqVar, FqVar, FqVar, FqVar, FqVar, FqVar),
+) -> Result<FqVar, SynthesisError> {
+    let params = (*crate::RATE_6_PARAMS).clone();
+    let ark_params = (params).into();
+
+    let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
+    poseidon_instance.absorb(&vec![
+        domain_separator,
+        &value.0,
+        &value.1,
+        &value.2,
+        &value.3,
+        &value.4,
+        &value.5,
+    ])?;
+    let output = poseidon_instance.squeeze_field_elements(1)?;
+    Ok(output[0].clone())
+}

--- a/poseidon377/tests/r1cs.rs
+++ b/poseidon377/tests/r1cs.rs
@@ -1,0 +1,110 @@
+use ark_ff::{One, PrimeField};
+use ark_groth16::{Groth16, ProvingKey, VerifyingKey};
+use once_cell::sync::Lazy;
+use proptest::prelude::*;
+
+use ark_r1cs_std::prelude::{AllocVar, EqGadget};
+use ark_relations::r1cs::{ConstraintSynthesizer, ToConstraintField};
+use ark_snark::SNARK;
+use decaf377::{
+    r1cs::{CountConstraints, FqVar},
+    Bls12_377, Fq,
+};
+use rand_core::OsRng;
+
+// This is a domain separator we'll use as a constant in our circuit below.
+static DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| Fq::from(666));
+
+#[derive(Clone)]
+struct PreimageCircuit {
+    // Witness
+    preimage: Fq,
+
+    // Public input
+    pub hash_output: Fq,
+}
+
+impl ConstraintSynthesizer<Fq> for PreimageCircuit {
+    fn generate_constraints(
+        self,
+        cs: ark_relations::r1cs::ConstraintSystemRef<Fq>,
+    ) -> ark_relations::r1cs::Result<()> {
+        let preimage_var = FqVar::new_witness(cs.clone(), || Ok(&self.preimage))?;
+
+        let domain_separator_var = FqVar::new_constant(cs.clone(), *DOMAIN_SEP)?;
+        let hash_output_var = FqVar::new_input(cs.clone(), || Ok(self.hash_output))?;
+
+        let test_hash_output = poseidon377::r1cs::hash_1(cs, &domain_separator_var, preimage_var)?;
+        hash_output_var.enforce_equal(&test_hash_output)?;
+
+        Ok(())
+    }
+}
+
+impl PreimageCircuit {
+    fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
+        let circuit = PreimageCircuit {
+            preimage: Fq::from(2),
+            hash_output: Fq::from(2),
+        };
+        let (pk, vk) = Groth16::circuit_specific_setup(circuit, &mut OsRng)
+            .expect("can perform circuit specific setup");
+        (pk, vk)
+    }
+}
+
+fn fq_strategy() -> BoxedStrategy<Fq> {
+    any::<[u8; 32]>()
+        .prop_map(|bytes| Fq::from_le_bytes_mod_order(&bytes[..]))
+        .boxed()
+}
+
+proptest! {
+#![proptest_config(ProptestConfig::with_cases(5))]
+#[test]
+fn groth16_hash_proof_happy_path(preimage in fq_strategy()) {
+        let (pk, vk) = PreimageCircuit::generate_test_parameters();
+        let mut rng = OsRng;
+
+        let hash_output = poseidon377::hash_1(&DOMAIN_SEP, preimage);
+
+        // Prover POV
+        let circuit = PreimageCircuit { preimage,hash_output };
+        let proof = Groth16::prove(&pk, circuit.clone(), &mut rng)
+            .expect("can generate proof");
+        dbg!(circuit.clone().num_constraints_and_instance_variables());
+
+        // Verifier POV
+        let processed_pvk = Groth16::process_vk(&vk).expect("can process verifying key");
+        let public_inputs = hash_output.to_field_elements().unwrap();
+        let proof_result =
+            Groth16::verify_with_processed_vk(&processed_pvk, &public_inputs, &proof).unwrap();
+
+        assert!(proof_result);
+    }
+}
+
+proptest! {
+#![proptest_config(ProptestConfig::with_cases(5))]
+#[test]
+fn groth16_hash_proof_unhappy_path(preimage in fq_strategy()) {
+        let (pk, vk) = PreimageCircuit::generate_test_parameters();
+        let mut rng = OsRng;
+
+        let hash_output = poseidon377::hash_1(&DOMAIN_SEP, preimage);
+
+        // Prover POV
+        let circuit = PreimageCircuit { preimage,hash_output };
+        let proof = Groth16::prove(&pk, circuit.clone(), &mut rng)
+            .expect("can generate proof");
+        dbg!(circuit.clone().num_constraints_and_instance_variables());
+
+        // Verifier POV
+        let processed_pvk = Groth16::process_vk(&vk).expect("can process verifying key");
+        let public_inputs = (hash_output + Fq::one()).to_field_elements().unwrap();
+        let proof_result =
+            Groth16::verify_with_processed_vk(&processed_pvk, &public_inputs, &proof).unwrap();
+
+        assert!(!proof_result);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/penumbra/issues/714

This PR adds an optional `r1cs` feature to `poseidon377` which lets us do fixed-width hashing in circuit. It also moves us to using the [`CryptographicSpongeVar`](https://docs.rs/ark-sponge/0.3.0/ark_sponge/constraints/trait.CryptographicSpongeVar.html) trait in both our (out of circuit) proptests and in circuit.

There's a Groth16 proof added in the tests directory that exercises the 1:1 hash, proving knowledge of the hash preimage. The circuit cost is 231 constraints.

Followup: Later on an optimization we can make is to replace the ark-sponge `PoseidonSpongeVar::permute` method with one that uses the optimized parameter set - see the text in PR #21 for more details and concrete numbers on the savings. This can done as a a drop-in change such that we do not need to modify the API in `poseidon377`.