### PR TITLE
only depend on ark-sponge in poseidon377 r1cs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "poseidon377",
     "poseidon-paramgen",
     "poseidon-permutation",
+    "poseidon-consistency",
 ]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains:
 * [`poseidon377`](../main/poseidon377): an instantiation of the Poseidon hash function for [`decaf377`](https://github.com/penumbra-zone/decaf377)
 * [`poseidon-paramgen`](../main/poseidon-paramgen): an independent implementation of Poseidon parameter generation
 * [`poseidon-permutation`](../main/poseidon-permutation): an independent implementation of the Poseidon permutation
+* [`poseidon-consistency`](../main/poseidon-consistency): property-based tests for consistency between Poseidon implementations
 
 ## Audits
 

--- a/poseidon-consistency/Cargo.toml
+++ b/poseidon-consistency/Cargo.toml
@@ -1,24 +1,29 @@
 [package]
-name = "poseidon-permutation"
+name = "poseidon-consistency"
 version = "0.1.0"
 edition = "2018"
 authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
-description = "An instantiation of the Poseidon permutation"
+description = "Checks consistency between Penumbra and Ark-sponge implementation"
 license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.8"
-ark-ff = "0.3"
 poseidon-paramgen = { version="0.1", path = "../poseidon-paramgen/" }
+poseidon-permutation = {version= "0.1", path="../poseidon-permutation/"}
+ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+decaf377 = "0.1"
 
 [dev-dependencies]
+criterion = { version = "0.3", features=["html_reports"] }
+ark-ff = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 num-bigint = "0.4"
-ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-criterion = { version = "0.3", features=["html_reports"] }
-once_cell = "1.8"
 proptest = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
+once_cell = "1.8"
+
+[[bench]]
+name = "permutation"
+harness = false

--- a/poseidon-consistency/benches/permutation.rs
+++ b/poseidon-consistency/benches/permutation.rs
@@ -9,6 +9,7 @@ use once_cell::sync::Lazy;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
 
+use poseidon_consistency::convert_to_ark_sponge_parameters;
 use poseidon_paramgen::PoseidonParameters;
 use poseidon_permutation::Instance;
 
@@ -16,7 +17,7 @@ static PARAMS_4_TO_1: Lazy<PoseidonParameters<Fq>> =
     Lazy::new(|| PoseidonParameters::<Fq>::new(128, 5, FqParameters::MODULUS, true));
 
 fn hash_4_1_ark_sponge(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let params_ark: Parameters<Fq> = (PARAMS_4_TO_1.clone()).into();
+    let params_ark: Parameters<Fq> = convert_to_ark_sponge_parameters(PARAMS_4_TO_1.clone());
 
     let mut poseidon_instance: PoseidonSponge<Fq> = PoseidonSponge::new(&params_ark);
     poseidon_instance.absorb(&vec![i, j, k, l, m]);

--- a/poseidon-consistency/src/lib.rs
+++ b/poseidon-consistency/src/lib.rs
@@ -1,0 +1,140 @@
+use ark_sponge::poseidon::PoseidonParameters as ArkPoseidonParameters;
+use decaf377::Fq;
+use poseidon_paramgen::{Alpha, PoseidonParameters};
+
+pub fn convert_to_ark_sponge_parameters(
+    params: PoseidonParameters<Fq>,
+) -> ArkPoseidonParameters<Fq> {
+    let alpha = match params.alpha {
+        Alpha::Exponent(exp) => exp as u64,
+        Alpha::Inverse => panic!("ark-sponge does not allow inverse alpha"),
+    };
+    // TODO: let user specify different capacity choices
+    let capacity = 1;
+    let rate = params.t - capacity;
+    let full_rounds = params.rounds.full();
+    let partial_rounds = params.rounds.partial();
+
+    ArkPoseidonParameters {
+        full_rounds,
+        partial_rounds,
+        alpha,
+        ark: params.arc.into(),
+        mds: params.mds.into(),
+        rate,
+        capacity,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poseidon_permutation::Instance;
+    use proptest::prelude::*;
+
+    use ark_ed_on_bls12_377::{Fq, FqParameters};
+    use ark_ff::FpParameters;
+    use ark_ff::{PrimeField, Zero};
+    use ark_sponge::{
+        poseidon::{PoseidonParameters as Parameters, PoseidonSponge},
+        CryptographicSponge,
+    };
+    use poseidon_paramgen::PoseidonParameters;
+
+    #[test]
+    fn check_optimized_impl_vs_sage() {
+        let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
+        let mut our_instance = Instance::new(&params_2_to_1);
+        let hash_output =
+            our_instance.n_to_1_fixed_hash(vec![Fq::zero(), Fq::from(1u64), Fq::from(2u64)]);
+        let output_words = our_instance.output_words();
+        assert_eq!(hash_output, output_words[1]);
+        let expected_output_words = [
+            ark_ff::field_new!(
+                Fq,
+                "6368779772888548211318735707249600947486536081021109980085678920065117075165"
+            ),
+            ark_ff::field_new!(
+                Fq,
+                "546637332213889354237126997303352456465330747031466737868777261691321847212"
+            ),
+            ark_ff::field_new!(
+                Fq,
+                "1488544471679348337017344865262529731114801536476862121626711131361325263279"
+            ),
+        ];
+        for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
+            assert_eq!(*a, *b);
+        }
+    }
+
+    #[test]
+    fn check_unoptimized_impl_vs_sage() {
+        let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
+        let mut our_instance = Instance::new(&params_2_to_1);
+        let hash_output = our_instance.unoptimized_n_to_1_fixed_hash(vec![
+            Fq::zero(),
+            Fq::from(1u64),
+            Fq::from(2u64),
+        ]);
+        let output_words = our_instance.output_words();
+        assert_eq!(hash_output, output_words[1]);
+        let expected_output_words = [
+            ark_ff::field_new!(
+                Fq,
+                "6368779772888548211318735707249600947486536081021109980085678920065117075165"
+            ),
+            ark_ff::field_new!(
+                Fq,
+                "546637332213889354237126997303352456465330747031466737868777261691321847212"
+            ),
+            ark_ff::field_new!(
+                Fq,
+                "1488544471679348337017344865262529731114801536476862121626711131361325263279"
+            ),
+        ];
+        for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
+            assert_eq!(*a, *b);
+        }
+    }
+
+    fn fq_strategy() -> BoxedStrategy<Fq> {
+        any::<[u8; 32]>()
+            .prop_map(|bytes| Fq::from_le_bytes_mod_order(&bytes[..]))
+            .boxed()
+    }
+
+    proptest! {
+        #[test]
+        fn ark_sponge_and_permutation_consistent(elem_1 in fq_strategy(), elem_2 in fq_strategy(), elem_3 in fq_strategy(), elem_4 in fq_strategy(), elem_5 in fq_strategy()) {
+            let t = 5;
+            let params_4_to_1 = PoseidonParameters::<Fq>::new(128, t, FqParameters::MODULUS, true);
+
+            let params_ark: Parameters<Fq> = convert_to_ark_sponge_parameters(params_4_to_1.clone());
+
+            let mut poseidon_instance: PoseidonSponge<Fq> = PoseidonSponge::new(&params_ark);
+            poseidon_instance.absorb(&vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+            let ark_result: Fq = poseidon_instance.squeeze_field_elements(1)[0];
+
+            let mut our_instance = Instance::new(&params_4_to_1);
+            let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+
+            assert_eq!(ark_result, our_result);
+        }
+
+        #[test]
+        fn optimized_and_unoptimized_permutation_consistent(elem_1 in fq_strategy(), elem_2 in fq_strategy(), elem_3 in fq_strategy(), elem_4 in fq_strategy(), elem_5 in fq_strategy()) {
+            let t = 5;
+            let params_4_to_1 = PoseidonParameters::<Fq>::new(128, t, FqParameters::MODULUS, true);
+
+            let mut our_instance = Instance::new(&params_4_to_1);
+            let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+
+            let mut unoptimized_instance = Instance::new(&params_4_to_1);
+            let unoptimized_result =
+                unoptimized_instance.unoptimized_n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+
+            assert_eq!(unoptimized_result, our_result);
+        }
+    }
+}

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 ark-ff = "0.3"
 merlin = "3.0"
 num = "0.4"

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "poseidon-paramgen"
 version = "0.1.0"
 edition = "2018"
-authors = ["Penumbra <crates@penumbra.zone>"]
+authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "A crate for generating Poseidon parameters"
 license = "MIT OR Apache-2.0"
 

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 ark-ff = "0.3"
 merlin = "3.0"
 num = "0.4"

--- a/poseidon-paramgen/src/lib.rs
+++ b/poseidon-paramgen/src/lib.rs
@@ -38,7 +38,6 @@ pub use rounds::RoundNumbers;
 pub use utils::log2;
 
 use ark_ff::PrimeField;
-use ark_sponge::poseidon::PoseidonParameters as ArkPoseidonParameters;
 
 /// A set of Poseidon parameters for a given set of input parameters.
 #[derive(Clone, Debug)]
@@ -94,30 +93,6 @@ impl<F: PrimeField> PoseidonParameters<F> {
             arc,
             optimized_mds,
             optimized_arc,
-        }
-    }
-}
-
-impl<F: PrimeField> Into<ArkPoseidonParameters<F>> for PoseidonParameters<F> {
-    fn into(self) -> ArkPoseidonParameters<F> {
-        let alpha = match self.alpha {
-            Alpha::Exponent(exp) => exp as u64,
-            Alpha::Inverse => panic!("ark-sponge does not allow inverse alpha"),
-        };
-        // TODO: let user specify different capacity choices
-        let capacity = 1;
-        let rate = self.t - capacity;
-        let full_rounds = self.rounds.full();
-        let partial_rounds = self.rounds.partial();
-
-        ArkPoseidonParameters {
-            full_rounds,
-            partial_rounds,
-            alpha,
-            ark: self.arc.into(),
-            mds: self.mds.into(),
-            rate,
-            capacity,
         }
     }
 }

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "poseidon-permutation"
 version = "0.1.0"
 edition = "2018"
-authors = ["Penumbra <crates@penumbra.zone>"]
+authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "An instantiation of the Poseidon permutation"
 license = "MIT OR Apache-2.0"
 

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 once_cell = "1.8"
 ark-ff = "0.3"
-poseidon-paramgen = { path = "../poseidon-paramgen/" }
+poseidon-paramgen = { version="0.1", path = "../poseidon-paramgen/" }
 
 [dev-dependencies]
 ark-ed-on-bls12-377 = "0.3"
 num-bigint = "0.4"
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 criterion = { version = "0.3", features=["html_reports"] }
 once_cell = "1.8"
 proptest = "1"

--- a/poseidon-permutation/src/permutation.rs
+++ b/poseidon-permutation/src/permutation.rs
@@ -44,8 +44,8 @@ impl<'a, F: PrimeField> Instance<'a, F> {
         self.state_words[1]
     }
 
-    #[cfg(test)]
-    pub(crate) fn output_words(&self) -> Vec<F> {
+    /// Print out internal state.
+    pub fn output_words(&self) -> Vec<F> {
         self.state_words.clone()
     }
 
@@ -255,117 +255,5 @@ impl<'a, F: PrimeField> Instance<'a, F> {
                 .sum::<F>();
 
         self.state_words[1..self.parameters.t].copy_from_slice(&add_row[..(self.parameters.t - 1)]);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
-    use ark_ed_on_bls12_377::{Fq, FqParameters};
-    use ark_ff::FpParameters;
-    use ark_ff::{PrimeField, Zero};
-    use ark_sponge::{
-        poseidon::{PoseidonParameters as Parameters, PoseidonSponge},
-        CryptographicSponge,
-    };
-    use poseidon_paramgen::PoseidonParameters;
-
-    #[test]
-    fn check_optimized_impl_vs_sage() {
-        let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
-        let mut our_instance = Instance::new(&params_2_to_1);
-        let hash_output =
-            our_instance.n_to_1_fixed_hash(vec![Fq::zero(), Fq::from(1u64), Fq::from(2u64)]);
-        let output_words = our_instance.output_words();
-        assert_eq!(hash_output, output_words[1]);
-        let expected_output_words = [
-            ark_ff::field_new!(
-                Fq,
-                "6368779772888548211318735707249600947486536081021109980085678920065117075165"
-            ),
-            ark_ff::field_new!(
-                Fq,
-                "546637332213889354237126997303352456465330747031466737868777261691321847212"
-            ),
-            ark_ff::field_new!(
-                Fq,
-                "1488544471679348337017344865262529731114801536476862121626711131361325263279"
-            ),
-        ];
-        for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
-            assert_eq!(*a, *b);
-        }
-    }
-
-    #[test]
-    fn check_unoptimized_impl_vs_sage() {
-        let params_2_to_1 = PoseidonParameters::<Fq>::new(128, 3, FqParameters::MODULUS, true);
-        let mut our_instance = Instance::new(&params_2_to_1);
-        let hash_output = our_instance.unoptimized_n_to_1_fixed_hash(vec![
-            Fq::zero(),
-            Fq::from(1u64),
-            Fq::from(2u64),
-        ]);
-        let output_words = our_instance.output_words();
-        assert_eq!(hash_output, output_words[1]);
-        let expected_output_words = [
-            ark_ff::field_new!(
-                Fq,
-                "6368779772888548211318735707249600947486536081021109980085678920065117075165"
-            ),
-            ark_ff::field_new!(
-                Fq,
-                "546637332213889354237126997303352456465330747031466737868777261691321847212"
-            ),
-            ark_ff::field_new!(
-                Fq,
-                "1488544471679348337017344865262529731114801536476862121626711131361325263279"
-            ),
-        ];
-        for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
-            assert_eq!(*a, *b);
-        }
-    }
-
-    fn fq_strategy() -> BoxedStrategy<Fq> {
-        any::<[u8; 32]>()
-            .prop_map(|bytes| Fq::from_le_bytes_mod_order(&bytes[..]))
-            .boxed()
-    }
-
-    proptest! {
-        #[test]
-        fn ark_sponge_and_permutation_consistent(elem_1 in fq_strategy(), elem_2 in fq_strategy(), elem_3 in fq_strategy(), elem_4 in fq_strategy(), elem_5 in fq_strategy()) {
-            let t = 5;
-            let params_4_to_1 = PoseidonParameters::<Fq>::new(128, t, FqParameters::MODULUS, true);
-
-            let params_ark: Parameters<Fq> = params_4_to_1.clone().into();
-
-            let mut poseidon_instance: PoseidonSponge<Fq> = PoseidonSponge::new(&params_ark);
-            poseidon_instance.absorb(&vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
-            let ark_result: Fq = poseidon_instance.squeeze_field_elements(1)[0];
-
-            let mut our_instance = Instance::new(&params_4_to_1);
-            let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
-
-            assert_eq!(ark_result, our_result);
-        }
-
-        #[test]
-        fn optimized_and_unoptimized_permutation_consistent(elem_1 in fq_strategy(), elem_2 in fq_strategy(), elem_3 in fq_strategy(), elem_4 in fq_strategy(), elem_5 in fq_strategy()) {
-            let t = 5;
-            let params_4_to_1 = PoseidonParameters::<Fq>::new(128, t, FqParameters::MODULUS, true);
-
-            let mut our_instance = Instance::new(&params_4_to_1);
-            let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
-
-            let mut unoptimized_instance = Instance::new(&params_4_to_1);
-            let unoptimized_result =
-                unoptimized_instance.unoptimized_n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
-
-            assert_eq!(unoptimized_result, our_result);
-        }
     }
 }

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -2,7 +2,7 @@
 name = "poseidon377"
 version = "0.1.0"
 edition = "2018"
-authors = ["Penumbra <crates@penumbra.zone>"]
+authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "An instantiation of the Poseidon hash for use with decaf377."
 license = "MIT OR Apache-2.0"
 
@@ -15,7 +15,7 @@ poseidon-paramgen = { version="0.1", path= "../poseidon-paramgen" }
 poseidon-permutation = { version="0.1", path= "../poseidon-permutation" }
 ark-relations = { version="0.3", optional=true }
 ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-decaf377 = {  version="0.1", git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+decaf377 = {  version="0.1", features = ["r1cs"] }
 num-bigint = "0.4.3"
 ark-groth16 = { version = "0.3", optional=true }
 ark-snark = { version = "0.3", optional=true }

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -11,11 +11,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 once_cell = "1.8"
 ark-ff = "0.3"
-poseidon-paramgen = { path= "../poseidon-paramgen" }
-poseidon-permutation = { path= "../poseidon-permutation" }
+poseidon-paramgen = { version="0.1", path= "../poseidon-paramgen" }
+poseidon-permutation = { version="0.1", path= "../poseidon-permutation" }
 ark-relations = { version="0.3", optional=true }
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-decaf377 = {  git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+decaf377 = {  version="0.1", git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
 num-bigint = "0.4.3"
 ark-groth16 = { version = "0.3", optional=true }
 ark-snark = { version = "0.3", optional=true }
@@ -37,7 +37,7 @@ name = "oldhash"
 harness = false
 
 [build-dependencies]
-poseidon-paramgen = { path = "../poseidon-paramgen/" }
+poseidon-paramgen = { version="0.1", path = "../poseidon-paramgen/" }
 ark-ed-on-bls12-377 = "0.3"
 ark-ff = "0.3"
 

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -14,7 +14,7 @@ ark-ff = "0.3"
 poseidon-paramgen = { version="0.1", path= "../poseidon-paramgen" }
 poseidon-permutation = { version="0.1", path= "../poseidon-permutation" }
 ark-relations = { version="0.3", optional=true }
-ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
+ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
 decaf377 = {  version="0.1", features = ["r1cs"] }
 num-bigint = "0.4.3"
 ark-groth16 = { version = "0.3", optional=true }

--- a/poseidon377/src/r1cs.rs
+++ b/poseidon377/src/r1cs.rs
@@ -1,9 +1,35 @@
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_sponge::{constraints::CryptographicSpongeVar, poseidon::constraints::PoseidonSpongeVar};
+use ark_sponge::{
+    constraints::CryptographicSpongeVar, poseidon::constraints::PoseidonSpongeVar,
+    poseidon::PoseidonParameters as ArkPoseidonParameters,
+};
+use poseidon_paramgen::{Alpha, PoseidonParameters};
 
 use decaf377::r1cs::FqVar;
 
 use crate::Fq;
+
+fn convert_to_ark_sponge_parameters(params: PoseidonParameters<Fq>) -> ArkPoseidonParameters<Fq> {
+    let alpha = match params.alpha {
+        Alpha::Exponent(exp) => exp as u64,
+        Alpha::Inverse => panic!("ark-sponge does not allow inverse alpha"),
+    };
+    // TODO: let user specify different capacity choices
+    let capacity = 1;
+    let rate = params.t - capacity;
+    let full_rounds = params.rounds.full();
+    let partial_rounds = params.rounds.partial();
+
+    ArkPoseidonParameters {
+        full_rounds,
+        partial_rounds,
+        alpha,
+        ark: params.arc.into(),
+        mds: params.mds.into(),
+        rate,
+        capacity,
+    }
+}
 
 pub fn hash_1(
     cs: ConstraintSystemRef<Fq>,
@@ -11,7 +37,7 @@ pub fn hash_1(
     value: FqVar,
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_1_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![domain_separator, &value])?;
@@ -25,7 +51,7 @@ pub fn hash_2(
     value: (FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_2_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![domain_separator, &value.0, &value.1])?;
@@ -39,7 +65,7 @@ pub fn hash_3(
     value: (FqVar, FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_3_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![domain_separator, &value.0, &value.1, &value.2])?;
@@ -53,7 +79,7 @@ pub fn hash_4(
     value: (FqVar, FqVar, FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_4_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![
@@ -73,7 +99,7 @@ pub fn hash_5(
     value: (FqVar, FqVar, FqVar, FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_5_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![
@@ -94,7 +120,7 @@ pub fn hash_6(
     value: (FqVar, FqVar, FqVar, FqVar, FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_6_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![
@@ -116,7 +142,7 @@ pub fn hash_7(
     value: (FqVar, FqVar, FqVar, FqVar, FqVar, FqVar, FqVar),
 ) -> Result<FqVar, SynthesisError> {
     let params = (*crate::RATE_7_PARAMS).clone();
-    let ark_params = (params).into();
+    let ark_params = convert_to_ark_sponge_parameters(params);
 
     let mut poseidon_instance: PoseidonSpongeVar<Fq> = PoseidonSpongeVar::new(cs, &ark_params);
     poseidon_instance.absorb(&vec![


### PR DESCRIPTION
We have tests that verify consistency between:
1. our Sage implementation of Poseidon (adapted from the paper's Sage spec)
2. our Rust implementation of Poseidon (in poseidon-permutation)
3. a fork of ark-sponge based on the 0.3 release

In this PR we move them into a crate poseidon-consistency that will not be published anywhere. The ark-sponge dependency is otherwise removed from poseidon-paramgen and poseidon-permutation, which only used ark-sponge in tests.

We still use the ark-sponge dependency in poseidon377 for the r1cs feature, which we may want to remove at a later date or switch from our fork to upstream such that we can publish the poseidon377 crate. But with these changes we should be able to publish the poseidon-paramgen and poseidon-permutation crates.