### PR TITLE
Enable poseidon in `no-std` environment

### DIFF
--- a/poseidon-consistency/Cargo.toml
+++ b/poseidon-consistency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-consistency"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "Checks consistency between Penumbra and Ark-sponge implementation"
@@ -9,10 +9,10 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-poseidon-paramgen = { version="0.1" }
-poseidon-permutation = {version= "0.1", path="../poseidon-permutation/"}
-ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-decaf377 = "0.1"
+poseidon-paramgen = { path = "../poseidon-paramgen", default-features = false }
+poseidon-permutation = { path="../poseidon-permutation", default-features = false }
+ark-sponge = { version="0.3", git = "https://github.com/penumbra-zone/sponge", branch = "r1cs", default-features = false }
+decaf377 = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.3", features=["html_reports"] }
@@ -27,3 +27,12 @@ once_cell = "1.8"
 [[bench]]
 name = "permutation"
 harness = false
+
+[features]
+default = ["std"]
+std = [
+    "poseidon-paramgen/std",
+    "poseidon-permutation/std",
+    "ark-sponge/std",
+]
+

--- a/poseidon-consistency/Cargo.toml
+++ b/poseidon-consistency/Cargo.toml
@@ -6,8 +6,6 @@ authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"
 description = "Checks consistency between Penumbra and Ark-sponge implementation"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 poseidon-paramgen = { path = "../poseidon-paramgen", default-features = false }
 poseidon-permutation = { path="../poseidon-permutation", default-features = false }

--- a/poseidon-consistency/src/lib.rs
+++ b/poseidon-consistency/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use ark_sponge::poseidon::PoseidonParameters as ArkPoseidonParameters;
 use decaf377::Fq;
 use poseidon_paramgen::{Alpha, PoseidonParameters};
@@ -28,18 +30,17 @@ pub fn convert_to_ark_sponge_parameters(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use poseidon_permutation::Instance;
-    use proptest::prelude::*;
-
     use ark_ed_on_bls12_377::{Fq, FqParameters};
-    use ark_ff::FpParameters;
-    use ark_ff::{PrimeField, Zero};
+    use ark_ff::{FpParameters, PrimeField, Zero};
     use ark_sponge::{
         poseidon::{PoseidonParameters as Parameters, PoseidonSponge},
         CryptographicSponge,
     };
     use poseidon_paramgen::PoseidonParameters;
+    use poseidon_permutation::Instance;
+    use proptest::prelude::*;
+
+    use super::*;
 
     #[test]
     fn check_optimized_impl_vs_sage() {

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "poseidon-paramgen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "A crate for generating Poseidon parameters"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = "1"
-ark-ff = "0.3"
-merlin = "3.0"
-num = "0.4"
-num-bigint = "0.4"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
+anyhow = { version = "1", default-features = false }
+ark-ff = { version = "0.3", default-features = false }
+ark-std = { version = "0.3", default-features = false }
+merlin = { version = "3.0", default-features = false }
+num = { version = "0.4", default-features = false }
+num-bigint = { version = "0.4", default-features = false }
+rand_core = { version = "0.6.3", default-features = false, features = ["getrandom"] }
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 ark-bls12-377 = "0.3"
@@ -23,3 +23,16 @@ ark-bn254 = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 ark-ed-on-bls12-381 = "0.3"
 proptest = "1"
+
+[features]
+default = ["std"]
+std = [
+    "anyhow/std",
+    "ark-ff/std",
+    "ark-std/std",
+    "merlin/std",
+    "num/std",
+    "num-bigint/std",
+    "rand_core/std",
+    "getrandom/std",
+]

--- a/poseidon-paramgen/src/alpha.rs
+++ b/poseidon-paramgen/src/alpha.rs
@@ -1,4 +1,5 @@
 use ark_ff::PrimeField;
+use ark_std::vec::Vec;
 use num::integer::gcd;
 use num_bigint::BigUint;
 
@@ -88,13 +89,13 @@ impl Alpha {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use ark_bn254::{Fq as Fq254, FqParameters as FqParameters254};
     use ark_ed_on_bls12_377::{Fq as Fq377, FqParameters as FqParameters377};
     use ark_ed_on_bls12_381::{Fq as Fq381, FqParameters as FqParameters381};
     use ark_ff::FpParameters;
     use num_bigint::BigInt;
+
+    use super::*;
 
     #[test]
     fn test_gcd() {

--- a/poseidon-paramgen/src/lib.rs
+++ b/poseidon-paramgen/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
 //! Module for generating parameters for the Poseidon SNARK-friendly hash function.
@@ -15,6 +16,9 @@
 //!
 //! [Poseidon paper]: https://eprint.iacr.org/2019/458.pdf
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod alpha;
 mod input;
 mod matrix;
@@ -25,9 +29,11 @@ mod transcript;
 mod utils;
 
 /// For generating parameters at build time.
+#[cfg(feature = "std")]
 pub mod poseidon_build;
 
 pub use alpha::Alpha;
+use ark_ff::PrimeField;
 pub use input::InputParameters;
 pub use matrix::{
     dot_product, mat_mul, Matrix, MatrixOperations, SquareMatrix, SquareMatrixOperations,
@@ -36,8 +42,6 @@ pub use mds::{MdsMatrix, OptimizedMdsMatrices};
 pub use round_constants::{ArcMatrix, OptimizedArcMatrix};
 pub use rounds::RoundNumbers;
 pub use utils::log2;
-
-use ark_ff::PrimeField;
 
 /// A set of Poseidon parameters for a given set of input parameters.
 #[derive(Clone, Debug)]

--- a/poseidon-paramgen/src/matrix.rs
+++ b/poseidon-paramgen/src/matrix.rs
@@ -21,11 +21,11 @@ pub use traits::{MatrixOperations, SquareMatrixOperations};
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use proptest::prelude::*;
-
     use ark_ed_on_bls12_377::Fq;
     use ark_ff::{One, PrimeField, Zero};
+    use proptest::prelude::*;
+
+    use super::*;
 
     #[test]
     fn identity_matrix() {

--- a/poseidon-paramgen/src/matrix/base.rs
+++ b/poseidon-paramgen/src/matrix/base.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use ark_ff::PrimeField;
+use ark_std::vec::Vec;
 
 use crate::MatrixOperations;
 

--- a/poseidon-paramgen/src/matrix/mult.rs
+++ b/poseidon-paramgen/src/matrix/mult.rs
@@ -1,7 +1,6 @@
-use std::ops::Mul;
-
 use anyhow::{anyhow, Result};
 use ark_ff::PrimeField;
+use ark_std::{ops::Mul, vec::Vec};
 
 use crate::{Matrix, MatrixOperations, SquareMatrix};
 

--- a/poseidon-paramgen/src/matrix/square.rs
+++ b/poseidon-paramgen/src/matrix/square.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use ark_ff::PrimeField;
+use ark_std::{vec, vec::Vec};
 
 use crate::{mat_mul, Matrix, MatrixOperations, SquareMatrixOperations};
 

--- a/poseidon-paramgen/src/matrix/traits.rs
+++ b/poseidon-paramgen/src/matrix/traits.rs
@@ -1,6 +1,7 @@
-use std::slice::Chunks;
+use core::slice::Chunks;
 
 use anyhow::Result;
+use ark_std::vec::Vec;
 
 /// Basic matrix operations all matrices should implement.
 pub trait MatrixOperations<F> {

--- a/poseidon-paramgen/src/mds.rs
+++ b/poseidon-paramgen/src/mds.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ark_ff::{BigInteger, PrimeField};
+use ark_std::vec::Vec;
 
 use crate::{
     matrix::mat_mul, InputParameters, Matrix, MatrixOperations, RoundNumbers, SquareMatrix,
@@ -356,13 +357,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::Alpha;
-
-    use super::*;
-
     use ark_ed_on_bls12_377::{Fq as Fq377, FqParameters as Fq377Parameters};
     use ark_ed_on_bls12_381::{Fq, FqParameters as Fq381Parameters};
     use ark_ff::{fields::FpParameters, One, Zero};
+
+    use super::*;
+    use crate::Alpha;
 
     #[test]
     fn convert_from_mds_to_vec_of_vecs() {

--- a/poseidon-paramgen/src/round_constants.rs
+++ b/poseidon-paramgen/src/round_constants.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ark_ff::PrimeField;
+use ark_std::{vec, vec::Vec};
 use merlin::Transcript;
 
 use crate::{
@@ -177,9 +178,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use ark_ed_on_bls12_377::Fq;
+
+    use super::*;
 
     #[test]
     fn convert_from_arc_to_vec_of_vecs() {

--- a/poseidon-paramgen/src/rounds.rs
+++ b/poseidon-paramgen/src/rounds.rs
@@ -1,6 +1,5 @@
-use std::cmp::{Ordering, PartialOrd};
-
 use ark_ff::BigInteger;
+use ark_std::cmp::{Ordering, PartialOrd};
 
 use super::{Alpha, InputParameters};
 

--- a/poseidon-paramgen/src/transcript.rs
+++ b/poseidon-paramgen/src/transcript.rs
@@ -1,4 +1,5 @@
 use ark_ff::{BigInteger, PrimeField};
+use ark_std::vec;
 use merlin::Transcript;
 
 use crate::{Alpha, InputParameters, RoundNumbers};

--- a/poseidon-paramgen/src/utils.rs
+++ b/poseidon-paramgen/src/utils.rs
@@ -1,6 +1,5 @@
-use std::convert::TryInto;
-
 use ark_ff::BigInteger;
+use ark_std::convert::TryInto;
 use num_bigint::BigUint;
 
 /// Computes the binary log of a `BigInteger`
@@ -32,10 +31,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use ark_ed_on_bls12_381::FqParameters as Fq381Parameters;
     use ark_ff::{BigInteger256, FpParameters};
+
+    use super::*;
 
     #[test]
     fn log2_bigint() {

--- a/poseidon-paramgen/tests/appendix_g.rs
+++ b/poseidon-paramgen/tests/appendix_g.rs
@@ -1,15 +1,12 @@
 #[allow(non_snake_case)]
 #[cfg(test)]
 mod tests {
-    use poseidon_paramgen::PoseidonParameters;
-    use poseidon_paramgen::{Alpha, InputParameters, RoundNumbers};
     use std::convert::TryFrom;
 
+    use ark_ed_on_bls12_377::{Fq, FqParameters as Fq377Parameters};
     use ark_ff::{fields::FpParameters, BigInteger768};
-
-    use ark_ed_on_bls12_377::Fq;
-    use ark_ed_on_bls12_377::FqParameters as Fq377Parameters;
     use num_bigint::BigUint;
+    use poseidon_paramgen::{Alpha, InputParameters, PoseidonParameters, RoundNumbers};
 
     /// Represents a row in Table 7-9 in Appendix G of the paper.
     #[allow(dead_code)]

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -6,8 +6,6 @@ authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"
 description = "An instantiation of the Poseidon permutation"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 once_cell = { version = "1.8", default-features = false }
 ark-ff = { version = "0.3", default-features = false }

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-permutation"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "An instantiation of the Poseidon permutation"
@@ -9,9 +9,9 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.8"
-ark-ff = "0.3"
-poseidon-paramgen = { version="0.1" }
+once_cell = { version = "1.8", default-features = false }
+ark-ff = { version = "0.3", default-features = false }
+poseidon-paramgen = { path = "../poseidon-paramgen", default-features = false }
 
 [dev-dependencies]
 ark-ed-on-bls12-377 = "0.3"
@@ -22,3 +22,11 @@ once_cell = "1.8"
 proptest = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
+
+[features]
+default = ["std"]
+std = [
+    "once_cell/std",
+    "ark-ff/std",
+    "poseidon-paramgen/std",
+]

--- a/poseidon-permutation/src/lib.rs
+++ b/poseidon-permutation/src/lib.rs
@@ -1,5 +1,6 @@
 //! An implemention of the Poseidon permutation for fixed-width
 //! hashing.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod permutation;
 

--- a/poseidon-permutation/src/permutation.rs
+++ b/poseidon-permutation/src/permutation.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 
-use ark_ff::PrimeField;
-
+use ark_ff::{vec, vec::Vec, PrimeField};
 use poseidon_paramgen::{Alpha, MatrixOperations, PoseidonParameters};
 
 /// Represents a generic instance of `Poseidon`.

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "poseidon377"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Penumbra <crates@penumbra.zone>", "redshiftzero <jen@penumbra.zone>"]
 description = "An instantiation of the Poseidon hash for use with decaf377."
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-once_cell = "1.8"
-ark-ff = "0.3"
-poseidon-paramgen = { version="0.1" }
-poseidon-permutation = { version="0.1", path= "../poseidon-permutation" }
-ark-relations = { version="0.3", optional=true }
-ark-sponge = { git = "https://github.com/penumbra-zone/sponge", branch = "r1cs" }
-decaf377 = {  version="0.1", features = ["r1cs"] }
-num-bigint = "0.4.3"
-ark-groth16 = { version = "0.3", optional=true }
-ark-snark = { version = "0.3", optional=true }
-ark-r1cs-std = {version = "0.3", optional=true }
+ark-ff = { version = "0.3", default-features = false }
+ark-groth16 = { version = "0.3", default-features = false, optional=true }
+ark-r1cs-std = {version = "0.3", default-features = false, optional=true }
+ark-relations = { version="0.3", default-features = false, optional=true }
+ark-snark = { version = "0.3", default-features = false, optional=true }
+decaf377 = { version="0.1", features = ["r1cs"] }
+num-bigint = { version = "0.4.3", default-features = false }
+once_cell = { version = "1.8", default-features = false }
+
+ark-sponge = { git = "https://github.com/penumbra-zone/sponge", default-features = false, branch = "r1cs" }
+
+poseidon-paramgen = { path = "../poseidon-paramgen", default-features = false }
+poseidon-permutation = { path = "../poseidon-permutation", default-features = false }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = "0.3"
@@ -29,7 +29,15 @@ rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand_chacha = "0.3"
 
 [features]
-default = []
+default = ["std"]
+std = [
+    "ark-ff/std",
+    "ark-groth16/std",
+    "ark-r1cs-std",
+    "ark-relations/std",
+    "num-bigint/std",
+    "once_cell/std",
+]
 r1cs = ["ark-groth16", "ark-relations", "ark-snark", "ark-r1cs-std"]
 
 [[bench]]
@@ -37,7 +45,7 @@ name = "oldhash"
 harness = false
 
 [build-dependencies]
-poseidon-paramgen = { version="0.1" }
+poseidon-paramgen = { path = "../poseidon-paramgen" }
 ark-ed-on-bls12-377 = "0.3"
 ark-ff = "0.3"
 

--- a/poseidon377/src/hash.rs
+++ b/poseidon377/src/hash.rs
@@ -1,3 +1,5 @@
+use ark_ff::vec;
+
 use crate::{Fq, Instance};
 
 /// Hash a single [`Fq`] element with the provided `domain_separator`.
@@ -81,8 +83,9 @@ pub fn hash_7(domain_separator: &Fq, value: (Fq, Fq, Fq, Fq, Fq, Fq, Fq)) -> Fq 
 
 #[cfg(test)]
 mod test {
-    use ark_ff::PrimeField;
     use std::str::FromStr;
+
+    use ark_ff::PrimeField;
 
     use super::*;
 

--- a/poseidon377/src/lib.rs
+++ b/poseidon377/src/lib.rs
@@ -1,4 +1,5 @@
 //! An instantiation of Poseidon for the BLS12-377 scalar field.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use once_cell::sync::Lazy;
 
@@ -7,10 +8,12 @@ mod hash;
 // We want the full parameters to be available in the documentation.
 #[cfg(doc)]
 pub mod params {
+    use ark_ff::vec;
     include!(concat!(env!("OUT_DIR"), "/params.rs"));
 }
 #[cfg(not(doc))]
 mod params {
+    use ark_ff::vec;
     include!(concat!(env!("OUT_DIR"), "/params.rs"));
 }
 


### PR DESCRIPTION
This PR enables every crate to be used in `no-std` environment. 

Now both commands should work fine:
```
cargo build
cargo build --no-default-features --target wasm32-unknown-unknown
```