### PR TITLE
crates w/ poseidon-parameters as a dependency need a version for publishing

### DIFF
--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -17,7 +17,7 @@ num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
 rand_core = { version = "0.6.3", default-features = false, features = ["getrandom"] }
 
-poseidon-parameters = { path = "../poseidon-parameters", default-features = false }
+poseidon-parameters = { path = "../poseidon-parameters", default-features = false, version = "0.2" }
 
 [dev-dependencies]
 ark-bn254 = "0.3"

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/penumbra-zone/poseidon377"
 ark-ff = { version = "0.3", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
 
-poseidon-parameters = { path = "../poseidon-parameters", default-features = false }
+poseidon-parameters = { path = "../poseidon-parameters", default-features = false, version = "0.2" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
The path specification of `poseidon-parameters` gets removed when publishing, and the [now published](https://crates.io/crates/poseidon-parameters) version on crates.io will be used, so we need to specify the version. 