### PR TITLE
Update poseidon-paramgen and poseidon-parameters to arkworks 0.4

### DIFF
--- a/poseidon-parameters/Cargo.toml
+++ b/poseidon-parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-parameters"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = []
 description = "A crate for Poseidon parameters"

--- a/poseidon-parameters/Cargo.toml
+++ b/poseidon-parameters/Cargo.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/penumbra-zone/poseidon377"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-ark-ff = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "^0.4.0", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
 
 [dev-dependencies]
-ark-ed-on-bls12-377 = "0.3"
+ark-ed-on-bls12-377 = "0.4"
 proptest = "1"
 
 [features]

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/penumbra-zone/poseidon377"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-ark-ff = { version = "0.3", default-features = false }
-ark-std = { version = "0.3", default-features = false }
+ark-ff = { version = "0.4", default-features = false }
+ark-std = { version = "0.4", default-features = false }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 merlin = { version = "3.0", default-features = false }
 num = { version = "0.4", default-features = false }
@@ -20,9 +20,9 @@ rand_core = { version = "0.6.3", default-features = false, features = ["getrando
 poseidon-parameters = { path = "../poseidon-parameters", default-features = false, version = "0.2" }
 
 [dev-dependencies]
-ark-bn254 = "0.3"
-ark-ed-on-bls12-377 = "0.3"
-ark-ed-on-bls12-381 = "0.3"
+ark-bn254 = "0.4"
+ark-ed-on-bls12-377 = "0.4"
+ark-ed-on-bls12-381 = "0.4"
 
 [features]
 default = ["std"]

--- a/poseidon-paramgen/Cargo.toml
+++ b/poseidon-paramgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-paramgen"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Penumbra <team@penumbralabs.xyz>", "redshiftzero <jen@penumbralabs.xyz>"]
 description = "A crate for generating Poseidon parameters"

--- a/poseidon-paramgen/src/alpha.rs
+++ b/poseidon-paramgen/src/alpha.rs
@@ -71,10 +71,9 @@ fn alpha_coprime_to_p_minus_one<F: PrimeField>(alpha: u32, p: F::BigInt) -> bool
 
 #[cfg(test)]
 mod tests {
-    use ark_bn254::{Fq as Fq254, FqParameters as FqParameters254};
-    use ark_ed_on_bls12_377::{Fq as Fq377, FqParameters as FqParameters377};
-    use ark_ed_on_bls12_381::{Fq as Fq381, FqParameters as FqParameters381};
-    use ark_ff::FpParameters;
+    use ark_bn254::Fq as Fq254;
+    use ark_ed_on_bls12_377::Fq as Fq377;
+    use ark_ed_on_bls12_381::Fq as Fq381;
     use num_bigint::BigInt;
 
     use super::*;
@@ -89,7 +88,7 @@ mod tests {
         assert_eq!(computed_gcd, BigInt::from(1u32));
         let computed_gcd = gcd(BigInt::from(11586173u32), BigInt::from(63141853u32));
         assert_eq!(computed_gcd, BigInt::from(1u32));
-        let p: BigUint = FqParameters377::MODULUS.into();
+        let p: BigUint = Fq377::MODULUS.into();
         let p_minus_one: BigUint = p - BigUint::from(1u32);
         let computed_gcd = gcd(BigInt::from(5u32), p_minus_one.into());
         assert_eq!(computed_gcd, BigInt::from(5u32))
@@ -99,17 +98,17 @@ mod tests {
     fn check_alpha_5() {
         // We know from the Poseidon paper that we should get an alpha of 5 for
         // BLS12-381 and BN254 (see Table 2)
-        let p = FqParameters381::MODULUS;
+        let p = Fq381::MODULUS;
         assert_eq!(generate::<Fq381>(p, true), Alpha::Exponent(5));
 
-        let p = FqParameters254::MODULUS;
+        let p = Fq254::MODULUS;
         assert_eq!(generate::<Fq254>(p, true), Alpha::Exponent(5));
     }
 
     #[test]
     fn check_alpha_17() {
         // For Poseidon377, we should get an alpha of 17 (from our own work).
-        let p = FqParameters377::MODULUS;
+        let p = Fq377::MODULUS;
         assert_eq!(generate::<Fq377>(p, true), Alpha::Exponent(17));
     }
 }

--- a/poseidon-paramgen/src/appendix_g.rs
+++ b/poseidon-paramgen/src/appendix_g.rs
@@ -3,8 +3,8 @@
 mod tests {
     use std::convert::TryFrom;
 
-    use ark_ed_on_bls12_377::{Fq, FqParameters as Fq377Parameters};
-    use ark_ff::{fields::FpParameters, BigInteger768};
+    use ark_ed_on_bls12_377::Fq;
+    use ark_ff::{BigInteger768, PrimeField};
     use num_bigint::BigUint;
     use poseidon_parameters::{Alpha, PoseidonParameters};
 
@@ -195,43 +195,38 @@ mod tests {
         let alpha = Alpha::Exponent(17);
 
         // $t=2$ corresponds to a 1:1 hash
-        let input = input::generate(128, 2, Fq377Parameters::MODULUS, true);
+        let input = input::generate(128, 2, Fq::MODULUS, true);
         let _rounds = rounds::generate(&input, &alpha);
         // Calling PoseidonParameters::new runs a bunch of assertions to ensure the optimized matrices
         // have been property constructed.
-        let _params_1_to_11: PoseidonParameters<Fq> =
-            generate(128, 2, Fq377Parameters::MODULUS, true);
+        let _params_1_to_11: PoseidonParameters<Fq> = generate(128, 2, Fq::MODULUS, true);
 
         // $t=3$ corresponds to a 2:1 hash
-        let input = input::generate(128, 3, Fq377Parameters::MODULUS, true);
+        let input = input::generate(128, 3, Fq::MODULUS, true);
         let rounds = rounds::generate(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
-        let _params_2_to_1: PoseidonParameters<Fq> =
-            generate(128, 3, Fq377Parameters::MODULUS, true);
+        let _params_2_to_1: PoseidonParameters<Fq> = generate(128, 3, Fq::MODULUS, true);
 
         // $t=4$ corresponds to a 3:1 hash
-        let input = input::generate(128, 4, Fq377Parameters::MODULUS, true);
+        let input = input::generate(128, 4, Fq::MODULUS, true);
         let rounds = rounds::generate(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
-        let _params_3_to_1: PoseidonParameters<Fq> =
-            generate(128, 4, Fq377Parameters::MODULUS, true);
+        let _params_3_to_1: PoseidonParameters<Fq> = generate(128, 4, Fq::MODULUS, true);
 
         // $t=5$ corresponds to a 4:1 hash
-        let input = input::generate(128, 5, Fq377Parameters::MODULUS, true);
+        let input = input::generate(128, 5, Fq::MODULUS, true);
         let rounds = rounds::generate(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
-        let _params_4_to_1: PoseidonParameters<Fq> =
-            generate(128, 5, Fq377Parameters::MODULUS, true);
+        let _params_4_to_1: PoseidonParameters<Fq> = generate(128, 5, Fq::MODULUS, true);
 
         // $t=6$ corresponds to a 5:1 hash
-        let input = input::generate(128, 6, Fq377Parameters::MODULUS, true);
+        let input = input::generate(128, 6, Fq::MODULUS, true);
         let rounds = rounds::generate(&input, &alpha);
         assert_eq!(rounds.full(), 8);
         assert_eq!(rounds.partial(), 31);
-        let _params_5_to_1: PoseidonParameters<Fq> =
-            generate(128, 6, Fq377Parameters::MODULUS, true);
+        let _params_5_to_1: PoseidonParameters<Fq> = generate(128, 6, Fq::MODULUS, true);
     }
 }

--- a/poseidon-paramgen/src/mds.rs
+++ b/poseidon-paramgen/src/mds.rs
@@ -201,9 +201,9 @@ fn doubleprime<F: PrimeField>(
 
 #[cfg(test)]
 mod tests {
-    use ark_ed_on_bls12_377::{Fq as Fq377, FqParameters as Fq377Parameters};
-    use ark_ed_on_bls12_381::{Fq, FqParameters as Fq381Parameters};
-    use ark_ff::{fields::FpParameters, One, Zero};
+    use ark_ed_on_bls12_377::Fq as Fq377;
+    use ark_ed_on_bls12_381::Fq;
+    use ark_ff::{One, Zero};
     use poseidon_parameters::Alpha;
 
     use super::*;
@@ -229,7 +229,7 @@ mod tests {
         let M = 128;
         let t = 3;
 
-        let input = input::generate(M, 3, Fq381Parameters::MODULUS, true);
+        let input = input::generate(M, 3, Fq::MODULUS, true);
         let MDS_matrix: MdsMatrix<Fq> = generate(&input);
 
         assert!(MDS_matrix.0.determinant() != Fq::zero());
@@ -241,15 +241,14 @@ mod tests {
     fn check_calc_equivalent_matrices_vs_sage() {
         let M = 128;
 
-        let input = input::generate(M, 3, Fq377Parameters::MODULUS, true);
+        let input = input::generate(M, 3, Fq377::MODULUS, true);
         let rounds = rounds::generate(&input, &Alpha::Exponent(17));
         let mds: MdsMatrix<Fq377> = generate(&input);
         let M_00 = mds.get_element(0, 0);
         // Sanity check
         assert_eq!(
             M_00,
-            ark_ff::field_new!(
-                Fq377,
+            ark_ff::MontFp!(
                 "5629641166285580282832549959187697687583932890102709218623488970611606159361"
             ),
         );
@@ -259,22 +258,18 @@ mod tests {
         // There are 31 (number of partial rounds) of these, we check the first 2 since it's the same method.
         let v_collection_expected = [
             [
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!(
                     "6333346312071277818186618704086159898531924501365547870951425091938056929281"
                 ),
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!(
                     "6755569399542696339399059951025237225100719468123251062348186764733927391233"
                 ),
             ],
             [
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!(
                     "7740756603642672888894756193883084320427907723891225175607297334590958469121"
                 ),
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!(
                     "7851338840837568215878966996652842667862592119946814106687401582227972161537"
                 ),
             ],
@@ -287,16 +282,14 @@ mod tests {
 
         let w_hat_collection_expected = [
             [
-                ark_ff::field_new!(Fq377, "3"),
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!("3"),
+                ark_ff::MontFp!(
                     "844446174942837042424882493878154653137589933515406382793523345591740923902"
                 ),
             ],
             [
-                ark_ff::field_new!(Fq377, "981"),
-                ark_ff::field_new!(
-                    Fq377,
+                ark_ff::MontFp!("981"),
+                ark_ff::MontFp!(
                     "1688892349885674084849764987756309306275179867030812765587046691183481846649"
                 ),
             ],
@@ -312,21 +305,17 @@ mod tests {
             Fq377::zero(),
             Fq377::zero(),
             Fq377::zero(),
-            ark_ff::field_new!(
-                Fq377,
+            ark_ff::MontFp!(
                 "1949629285152675843545617098663080067734218406516000484720630379218497119024"
             ),
-            ark_ff::field_new!(
-                Fq377,
+            ark_ff::MontFp!(
                 "6804287869450188502728877251894011667833647269738979685488937504164506768586"
             ),
             Fq377::zero(),
-            ark_ff::field_new!(
-                Fq377,
+            ark_ff::MontFp!(
                 "6804287869450188502728877251894011667833647269738979685488937504164506768586"
             ),
-            ark_ff::field_new!(
-                Fq377,
+            ark_ff::MontFp!(
                 "4924677972410444052137834859533533887056104638988047570112284264367323462906"
             ),
         ];

--- a/poseidon-paramgen/src/transcript.rs
+++ b/poseidon-paramgen/src/transcript.rs
@@ -34,7 +34,7 @@ impl TranscriptProtocol for Transcript {
     }
 
     fn round_constant<F: PrimeField>(&mut self) -> F {
-        let size_in_bytes = (F::size_in_bits() + 135) / 8;
+        let size_in_bytes = (F::MODULUS_BIT_SIZE as usize + 135) / 8;
         let mut dest = vec![0u8; size_in_bytes];
         self.challenge_bytes(b"round-constant", &mut dest);
         F::from_le_bytes_mod_order(&dest)

--- a/poseidon-paramgen/src/utils.rs
+++ b/poseidon-paramgen/src/utils.rs
@@ -31,24 +31,24 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ark_ed_on_bls12_381::FqParameters as Fq381Parameters;
-    use ark_ff::{BigInteger256, FpParameters};
+    use ark_ed_on_bls12_381::Fq;
+    use ark_ff::{BigInteger256, PrimeField};
 
     use super::*;
 
     #[test]
     fn log2_bigint() {
-        let test_val: BigInteger256 = 4.into();
+        let test_val: BigInteger256 = ark_ff::BigInt!("4");
         assert_eq!(log2(test_val), 2.0);
 
-        let test_val: BigInteger256 = 257.into();
+        let test_val: BigInteger256 = ark_ff::BigInt!("257");
         assert!(log2(test_val) > 8.005);
         assert!(log2(test_val) < 8.006);
 
-        let test_val: BigInteger256 = 65536.into();
+        let test_val: BigInteger256 = ark_ff::BigInt!("65536");
         assert_eq!(log2(test_val), 16.0);
 
-        let test_val = Fq381Parameters::MODULUS;
+        let test_val = Fq::MODULUS;
         assert!(log2(test_val) > 254.856);
         assert!(log2(test_val) < 254.858);
     }


### PR DESCRIPTION
This makes the poseidon-paramgen crate support arkworks 0.4 by updating the poseidon-paramgen and poseidon-parameters projects to the new arkworks version.

Note that the other projects in this repository have not been ported to 0.4, so this will make the rest of this repository incompatible with the updated crates.