### PR TITLE
poseidon2: rounds, internal matrix for small state sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ parameters
 ## Audits
 
 `poseidon-paramgen` [was audited](https://research.nccgroup.com/2022/09/12/public-report-penumbra-labs-decaf377-implementation-and-poseidon-parameter-selection-review/) by NCC Group in Summer 2022.
+Note that the audit covered only the parameter generation described in the original Poseidon paper. The Poseidon2 parameter
+generation is not yet audited.
 
 ## Benchmarks
 

--- a/poseidon-parameters/src/alpha.rs
+++ b/poseidon-parameters/src/alpha.rs
@@ -16,3 +16,12 @@ impl Alpha {
         }
     }
 }
+
+impl From<Alpha> for f64 {
+    fn from(alpha: Alpha) -> Self {
+        match alpha {
+            Alpha::Exponent(exp) => exp as f64,
+            Alpha::Inverse => -1.0,
+        }
+    }
+}

--- a/poseidon-parameters/src/matrix.rs
+++ b/poseidon-parameters/src/matrix.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use ark_ff::{vec, vec::Vec, PrimeField};
 use num_integer::Roots;
 
-use crate::matrix_ops::{mat_mul, MatrixOperations, SquareMatrixOperations};
+use crate::matrix_ops::{mat_mul, MatrixOperations, Polynomial, SquareMatrixOperations};
 
 /// Represents a matrix over `PrimeField` elements.
 ///
@@ -310,6 +310,11 @@ impl<F: PrimeField> SquareMatrixOperations<F> for SquareMatrix<F> {
                 det
             }
         }
+    }
+
+    /// Compute the minimal polynomial of the matrix.
+    fn min_poly(&self) -> Polynomial<F> {
+        unimplemented!("min_poly not yet implemented")
     }
 }
 

--- a/poseidon-parameters/src/matrix.rs
+++ b/poseidon-parameters/src/matrix.rs
@@ -311,11 +311,6 @@ impl<F: PrimeField> SquareMatrixOperations<F> for SquareMatrix<F> {
             }
         }
     }
-
-    /// Compute the minimal polynomial of the matrix.
-    fn min_poly(&self) -> Polynomial<F> {
-        unimplemented!("min_poly not yet implemented")
-    }
 }
 
 /// Multiply scalar by SquareMatrix

--- a/poseidon-parameters/src/matrix_ops.rs
+++ b/poseidon-parameters/src/matrix_ops.rs
@@ -136,8 +136,6 @@ pub trait SquareMatrixOperations<F> {
     fn cofactors(&self) -> Self;
     /// Compute the matrix determinant
     fn determinant(&self) -> F;
-    /// Compute the minimal polynomial
-    fn min_poly(&self) -> Polynomial<F>;
 }
 
 #[cfg(test)]

--- a/poseidon-parameters/src/matrix_ops.rs
+++ b/poseidon-parameters/src/matrix_ops.rs
@@ -64,6 +64,64 @@ pub fn dot_product<F: PrimeField>(a: &[F], b: &[F]) -> F {
     a.iter().zip(b.iter()).map(|(x, y)| *x * *y).sum()
 }
 
+pub struct Polynomial<F> {
+    /// The coefficients of the polynomial a_0, ..., a_i
+    pub coeffs: Vec<F>,
+}
+
+impl<F: PrimeField> Polynomial<F> {
+    /// Construct a new polynomial
+    pub fn new(coeffs: Vec<F>) -> Self {
+        Self { coeffs }
+    }
+
+    /// Degree of the polynomial
+    pub fn max_degree(&self) -> usize {
+        self.coeffs.len() - 1
+    }
+
+    /// Evaluate the polynomial at a given point
+    pub fn evaluate(&self, x: F) -> F {
+        self.coeffs
+            .iter()
+            .rev()
+            .fold(F::zero(), |acc, coeff| acc * x + coeff)
+    }
+
+    /// Check if the polynomial is irreducible using Perron's irreducibility criterion.
+    pub fn is_irreducible(&self) -> bool {
+        // We first need to check the polynomial is monic.
+        if self.coeffs.last() != Some(&F::one()) {
+            unimplemented!("polynomial is not monic, not sure how to check irreducibility")
+        } else {
+            // The polynomial is monic, so we can apply Perron's criterion.
+            // See https://en.wikipedia.org/wiki/Perron%27s_irreducibility_criterion
+            // for more details.
+            let n = self.max_degree();
+            let mut sum = F::one();
+            for i in 0..n - 1 {
+                sum += self.coeffs[i];
+            }
+
+            match self.coeffs[n - 1] {
+                // Condition 1:
+                // $\abs{a_{n-1}} > 1 + \abs{a_{n-2}} + ... + \abs{a_0}$
+                coeff if coeff > sum => true,
+                // Condition 2:
+                // $\abs{a_{n-1}} = 1 + \abs{a_{n-2}} + ... + \abs{a_0}$
+                // AND
+                // f(1) != 0 AND f(-1) != 0
+                coeff if coeff == sum => {
+                    let f_of_1 = self.evaluate(F::one());
+                    let f_of_neg_1 = self.evaluate(-F::one());
+                    f_of_1 != F::zero() && f_of_neg_1 != F::zero()
+                }
+                _ => false,
+            }
+        }
+    }
+}
+
 /// Matrix operations that are defined on square matrices.
 pub trait SquareMatrixOperations<F> {
     /// Compute the matrix inverse, if it exists
@@ -78,4 +136,20 @@ pub trait SquareMatrixOperations<F> {
     fn cofactors(&self) -> Self;
     /// Compute the matrix determinant
     fn determinant(&self) -> F;
+    /// Compute the minimal polynomial
+    fn min_poly(&self) -> Polynomial<F>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ed_on_bls12_377::Fq;
+
+    #[test]
+    fn poly_evaluate() {
+        // f(x) = 1 + 2x + 3x^2
+        let poly = Polynomial::new(vec![Fq::from(1), Fq::from(2), Fq::from(3)]);
+        assert_eq!(poly.max_degree(), 2);
+        assert_eq!(poly.evaluate(Fq::from(2)), Fq::from(17));
+    }
 }

--- a/poseidon-parameters/src/v2.rs
+++ b/poseidon-parameters/src/v2.rs
@@ -5,7 +5,9 @@ pub use crate::arc_matrix::ArcMatrix;
 pub use crate::matrix::SquareMatrix;
 pub use crate::round_numbers::RoundNumbers;
 
-pub use crate::{matrix_ops::MatrixOperations, matrix_ops::SquareMatrixOperations};
+pub use crate::{
+    matrix_ops::MatrixOperations, matrix_ops::Polynomial, matrix_ops::SquareMatrixOperations,
+};
 
 /// A set of Poseidon2 parameters for a given set of input parameters.
 #[derive(Clone, Debug)]

--- a/poseidon-paramgen/CHANGELOG.md
+++ b/poseidon-paramgen/CHANGELOG.md
@@ -13,4 +13,5 @@
 
 # 0.4.0
 
-* Add `v1` and `v2` APIs.
+* Add `v1` and `v2` APIs. Note the `v2` parameter generation has not been
+audited at the time of release.

--- a/poseidon-paramgen/src/appendix_g.rs
+++ b/poseidon-paramgen/src/appendix_g.rs
@@ -82,6 +82,14 @@ mod tests {
             };
             let input = InputParameters::generate(table_row.M, table_row.t, table_row.p, true);
             let rounds = rounds::v1_generate(&input, &alpha);
+
+            // For bits of security of 256 bits or less, v2 parameter generation should be unchanged.
+            if table_row.M <= 256 {
+                let rounds2 = rounds::v2_generate(&input, &alpha);
+                assert_eq!(rounds.full(), rounds2.full());
+                assert_eq!(rounds.partial(), rounds2.partial());
+            }
+
             assert_eq!(rounds.full(), table_row.r_F);
             assert_eq!(rounds.partial(), table_row.r_P);
         }
@@ -135,6 +143,14 @@ mod tests {
             let input: InputParameters<ark_ff::BigInt<12>> =
                 InputParameters::generate(table_row.M, table_row.t, table_row.p, true);
             let rounds = rounds::v1_generate(&input, &alpha);
+
+            // For bits of security of 256 bits or less, v2 parameter generation should be unchanged.
+            if table_row.M <= 256 {
+                let rounds2 = rounds::v2_generate(&input, &alpha);
+                assert_eq!(rounds.full(), rounds2.full());
+                assert_eq!(rounds.partial(), rounds2.partial());
+            }
+
             assert_eq!(rounds.full(), table_row.r_F);
             assert_eq!(rounds.partial(), table_row.r_P);
         }

--- a/poseidon-paramgen/src/v2/internal.rs
+++ b/poseidon-paramgen/src/v2/internal.rs
@@ -1,7 +1,84 @@
 use ark_ff::PrimeField;
-use poseidon_parameters::v2::SquareMatrix;
+use poseidon_parameters::v2::{SquareMatrix, SquareMatrixOperations};
 
 /// Generate internal matrix
-pub fn generate<F: PrimeField>(_t: usize) -> SquareMatrix<F> {
-    unimplemented!()
+///
+/// This matrix needs to be invertible, and no arbitrarily long
+/// subspace trails should exist.
+pub fn generate<F: PrimeField>(t: usize) -> SquareMatrix<F> {
+    let M_i: SquareMatrix<F>;
+
+    if t == 2 {
+        M_i = SquareMatrix::<F>::from_vec(vec![F::from(2u64), F::one(), F::one(), F::from(3u64)]);
+    } else if t == 3 {
+        M_i = SquareMatrix::<F>::from_vec(vec![
+            F::from(2u64),
+            F::one(),
+            F::one(),
+            F::one(),
+            F::from(2u64),
+            F::one(),
+            F::one(),
+            F::one(),
+            F::from(3u64),
+        ]);
+    } else {
+        // From Section 5.3 of the Poseidon2 paper, in lieu of implementing
+        // the three algorithms defined in Grassi et al. 2020 [0] to check
+        // for arbitrarily long subspace trails, we can instead check that the
+        // minimal polynomials of the matrices M_i, M_i^2, ..., are irreducible
+        // and of maximum degree. If that is true, then no arbitrarily long
+        // subspace trails exist. See Proposition 12 and its proof in [0].
+        //
+        // [0] https://eprint.iacr.org/2020/500
+        unimplemented!("internal matrix for t >= 4 not yet implemented")
+    }
+
+    // Check the matrix is invertible.
+    assert!(M_i.inverse().is_ok());
+
+    M_i
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ed_on_bls12_377::Fq;
+    use poseidon_parameters::v2::MatrixOperations;
+
+    use super::*;
+
+    #[test]
+    fn internal_matrix_t_equals_2() {
+        let matrix: SquareMatrix<Fq> = generate(2);
+        // The off-diagonal elements should be 1. The diagonals are non-zero.
+
+        // Row 0
+        assert_eq!(Fq::from(2u64), matrix.get_element(0, 0));
+        assert_eq!(Fq::from(1u64), matrix.get_element(0, 1));
+
+        // Row 1
+        assert_eq!(Fq::from(1u64), matrix.get_element(1, 0));
+        assert_eq!(Fq::from(3u64), matrix.get_element(1, 1));
+    }
+
+    #[test]
+    fn internal_matrix_t_equals_3() {
+        let matrix: SquareMatrix<Fq> = generate(3);
+        // The off-diagonal elements should be 1. The diagonals are non-zero.
+
+        // Row 0
+        assert_eq!(Fq::from(2u64), matrix.get_element(0, 0));
+        assert_eq!(Fq::from(1u64), matrix.get_element(0, 1));
+        assert_eq!(Fq::from(1u64), matrix.get_element(0, 2));
+
+        // Row 1
+        assert_eq!(Fq::from(1u64), matrix.get_element(1, 0));
+        assert_eq!(Fq::from(2u64), matrix.get_element(1, 1));
+        assert_eq!(Fq::from(1u64), matrix.get_element(1, 2));
+
+        // Row 2
+        assert_eq!(Fq::from(1u64), matrix.get_element(2, 0));
+        assert_eq!(Fq::from(1u64), matrix.get_element(2, 1));
+        assert_eq!(Fq::from(3u64), matrix.get_element(2, 2));
+    }
 }


### PR DESCRIPTION
Closes #45: in this PR we implement the round calculation for Poseidon2, and add a panic to the impacted state sizes of Poseidon1's round calculation in light of the attacks presented in https://eprint.iacr.org/2023/537. 

This PR also has the start of the internal matrix calculation for Poseidon2 for #40. The remaining work here is to implement functionality that computes the minimal polynomial of a proposed internal matrix. See comment [here](https://github.com/penumbra-zone/poseidon377/compare/poseidon2-rounds?expand=1#diff-d9f43780a31de1cd7a6fa67cb9adfb505c60ad5e3ea22f0b19bce4fa1bb360d4R26-R33) for more explanation. 