### PR TITLE
fix: remove debugging lines (left in during #49)

### DIFF
--- a/poseidon-parameters/src/matrix.rs
+++ b/poseidon-parameters/src/matrix.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use ark_ff::{vec, vec::Vec, PrimeField};
 use num_integer::Roots;
 
-use crate::matrix_ops::{mat_mul, MatrixOperations, Polynomial, SquareMatrixOperations};
+use crate::matrix_ops::{mat_mul, MatrixOperations, SquareMatrixOperations};
 
 /// Represents a matrix over `PrimeField` elements.
 ///

--- a/poseidon-permutation/CHANGELOG.md
+++ b/poseidon-permutation/CHANGELOG.md
@@ -15,3 +15,7 @@
 
 * Use `v1` APIs from parameter crates.
 * Use `poseidon-permutation` R1CS implementation.
+
+# 0.5.0
+
+* Fix: Removing unnecessary debug output.

--- a/poseidon-permutation/Cargo.toml
+++ b/poseidon-permutation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon-permutation"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 authors = ["Penumbra <team@penumbralabs.xyz>", "redshiftzero <jen@penumbralabs.xyz>"]
 description = "An instantiation of the Poseidon permutation"

--- a/poseidon-permutation/src/r1cs.rs
+++ b/poseidon-permutation/src/r1cs.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 use ark_ff::PrimeField;
-use ark_std::{dbg, vec::Vec};
+use ark_std::vec::Vec;
 
 use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::ConstraintSystemRef;
@@ -63,9 +63,7 @@ where
                 self.state_words[i] += round_constants[round_constants_counter];
                 round_constants_counter += 1;
             }
-            dbg!("bout to SubWord: ", self.cs.num_constraints());
             self.full_sub_words();
-            dbg!("after x^a: ", self.cs.num_constraints());
             self.mix_layer_mds();
         }
 

--- a/poseidon377/CHANGELOG.md
+++ b/poseidon377/CHANGELOG.md
@@ -18,3 +18,7 @@
 # 0.5.0
 
 * Use `poseidon-permutation` R1CS implementation.
+
+# 0.6.0
+
+* Use `poseidon-permutation` version 0.5.0 to avoid spurious debug output.

--- a/poseidon377/Cargo.toml
+++ b/poseidon377/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon377"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 authors = ["Penumbra <team@penumbralabs.xyz>", "redshiftzero <jen@penumbralabs.xyz>"]
 description = "An instantiation of the Poseidon hash for use with decaf377."
@@ -17,7 +17,7 @@ decaf377 = { version="0.4", default-features = false, features = ["r1cs"] }
 num-bigint = { version = "0.4.3", default-features = false }
 once_cell = { version = "1.8", default-features = false }
 poseidon-parameters = { version="0.4", path = "../poseidon-parameters", default-features = false }
-poseidon-permutation = { version="0.4", path = "../poseidon-permutation", default-features = false }
+poseidon-permutation = { version="0.5", path = "../poseidon-permutation", default-features = false }
 
 # Dependencies added for ark-sponge vendoring
 ark-ec = { version = "0.4", default_features = false, optional=true }


### PR DESCRIPTION
I left in two debug lines when preparing #49, discovered by @conorsch.