### PR TITLE
fix benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "poseidon377",
     # "poseidon-paramgen" # Temporarily excluded until refactored
     "poseidon-permutation",
-    # "poseidon-consistency", # Temporarily excluded until paramgen is refactored
+    "poseidon-consistency",
     "poseidon-parameters",
     "poseidon-tests",
 ]

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ cargo bench
 ```
 
 This will generate a report at `target/criterion/report/index.html`.
+
+Performance benchmarked on commit 9750f5ff01d11f158f111a1a75401901049e5575 on
+a 2023 Macbook Pro M2 (12 core CPU) with 32 GB memory using our 4-to-1 optimized
+poseidon hash takes 47.3µs, or ~21,141 hashes/second.

--- a/poseidon-consistency/Cargo.toml
+++ b/poseidon-consistency/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/penumbra-zone/poseidon377"
 [dependencies]
 poseidon-parameters = { path = "../poseidon-parameters", default-features = false  }
 #poseidon-paramgen = { path = "../poseidon-paramgen", default-features = false }
+poseidon377 = { path = "../poseidon377", default-features = false }
 poseidon-permutation = { path="../poseidon-permutation", default-features = false }
 decaf377 = { version="0.10.1", default-features = false }
 
@@ -30,7 +31,8 @@ harness = false
 [features]
 default = ["std"]
 std = [
-    "poseidon-paramgen/std",
     "poseidon-permutation/std",
 ]
-
+arkworks = [
+    "decaf377/arkworks",
+]

--- a/poseidon-consistency/benches/permutation.rs
+++ b/poseidon-consistency/benches/permutation.rs
@@ -18,7 +18,7 @@ fn hash_4_1_our_impl_unoptimized(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
 
 pub fn bench_unoptimized_vs_optimized(c: &mut Criterion) {
     let mut group = c.benchmark_group("unoptimized_vs_optimized");
-    let n = 10;
+    let n = 100;
     let mut rng = ChaChaRng::seed_from_u64(666);
     let mut test_field_elements = Vec::with_capacity(n);
 

--- a/poseidon-consistency/benches/permutation.rs
+++ b/poseidon-consistency/benches/permutation.rs
@@ -1,23 +1,19 @@
-use ark_ed_on_bls12_377::{Fq, FqConfig};
-use ark_ff::{MontConfig, PrimeField};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use once_cell::sync::Lazy;
+use decaf377::Fq;
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};
 
+use poseidon377::RATE_4_PARAMS;
 use poseidon_permutation::Instance;
 
-static PARAMS_4_TO_1: Lazy<poseidon_parameters::v1::PoseidonParameters<Fq>> =
-    Lazy::new(|| poseidon_paramgen::v1::generate(128, 5, FqConfig::MODULUS, true));
-
 fn hash_4_1_our_impl(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let mut our_instance = Instance::new(&PARAMS_4_TO_1);
-    our_instance.n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
+    let mut our_instance = Instance::new(&RATE_4_PARAMS);
+    our_instance.n_to_1_fixed_hash(&[*i, *j, *k, *l, *m])
 }
 
 fn hash_4_1_our_impl_unoptimized(i: &Fq, j: &Fq, k: &Fq, l: &Fq, m: &Fq) -> Fq {
-    let mut our_instance = Instance::new(&PARAMS_4_TO_1);
-    our_instance.unoptimized_n_to_1_fixed_hash(vec![*i, *j, *k, *l, *m])
+    let mut our_instance = Instance::new(&RATE_4_PARAMS);
+    our_instance.unoptimized_n_to_1_fixed_hash([*i, *j, *k, *l, *m])
 }
 
 pub fn bench_unoptimized_vs_optimized(c: &mut Criterion) {

--- a/poseidon-consistency/src/lib.rs
+++ b/poseidon-consistency/src/lib.rs
@@ -1,31 +1,37 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(test)]
+#[cfg(all(test, feature = "arkworks"))]
 mod tests {
-    use ark_ed_on_bls12_377::{Fq, FqConfig};
-    use ark_ff::{MontConfig, PrimeField, Zero};
-    use poseidon_paramgen::v1::generate;
+    use ark_ed_on_bls12_377::Fq as ArkFq;
+    use ark_ff::BigInteger256;
+
+    use decaf377::Fq;
+    use poseidon377::{RATE_2_PARAMS, RATE_4_PARAMS};
     use poseidon_permutation::Instance;
     use proptest::prelude::*;
 
+    pub(crate) fn from_ark_fq(x: ArkFq) -> Fq {
+        BigInteger256::from(x).into()
+    }
+
     #[test]
     fn check_optimized_impl_vs_sage() {
-        let params_2_to_1 = generate(128, 3, FqConfig::MODULUS, true);
+        let params_2_to_1 = RATE_2_PARAMS;
         let mut our_instance = Instance::new(&params_2_to_1);
         let hash_output =
-            our_instance.n_to_1_fixed_hash(vec![Fq::zero(), Fq::from(1u64), Fq::from(2u64)]);
+            our_instance.n_to_1_fixed_hash(&[Fq::from(0u64), Fq::from(1u64), Fq::from(2u64)]);
         let output_words = our_instance.output_words();
         assert_eq!(hash_output, output_words[1]);
         let expected_output_words = [
-            ark_ff::MontFp!(
+            from_ark_fq(ark_ff::MontFp!(
                 "6368779772888548211318735707249600947486536081021109980085678920065117075165"
-            ),
-            ark_ff::MontFp!(
+            )),
+            from_ark_fq(ark_ff::MontFp!(
                 "546637332213889354237126997303352456465330747031466737868777261691321847212"
-            ),
-            ark_ff::MontFp!(
+            )),
+            from_ark_fq(ark_ff::MontFp!(
                 "1488544471679348337017344865262529731114801536476862121626711131361325263279"
-            ),
+            )),
         ];
         for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
             assert_eq!(*a, *b);
@@ -34,25 +40,25 @@ mod tests {
 
     #[test]
     fn check_unoptimized_impl_vs_sage() {
-        let params_2_to_1 = generate(128, 3, FqConfig::MODULUS, true);
+        let params_2_to_1 = RATE_2_PARAMS;
         let mut our_instance = Instance::new(&params_2_to_1);
-        let hash_output = our_instance.unoptimized_n_to_1_fixed_hash(vec![
-            Fq::zero(),
+        let hash_output = our_instance.unoptimized_n_to_1_fixed_hash([
+            Fq::from(0u64),
             Fq::from(1u64),
             Fq::from(2u64),
         ]);
         let output_words = our_instance.output_words();
         assert_eq!(hash_output, output_words[1]);
         let expected_output_words = [
-            ark_ff::MontFp!(
+            from_ark_fq(ark_ff::MontFp!(
                 "6368779772888548211318735707249600947486536081021109980085678920065117075165"
-            ),
-            ark_ff::MontFp!(
+            )),
+            from_ark_fq(ark_ff::MontFp!(
                 "546637332213889354237126997303352456465330747031466737868777261691321847212"
-            ),
-            ark_ff::MontFp!(
+            )),
+            from_ark_fq(ark_ff::MontFp!(
                 "1488544471679348337017344865262529731114801536476862121626711131361325263279"
-            ),
+            )),
         ];
         for (a, b) in expected_output_words.iter().zip(output_words.iter()) {
             assert_eq!(*a, *b);
@@ -68,15 +74,14 @@ mod tests {
     proptest! {
         #[test]
         fn optimized_and_unoptimized_permutation_consistent(elem_1 in fq_strategy(), elem_2 in fq_strategy(), elem_3 in fq_strategy(), elem_4 in fq_strategy(), elem_5 in fq_strategy()) {
-            let t = 5;
-            let params_4_to_1 = generate(128, t, FqConfig::MODULUS, true);
+            let params_4_to_1 = RATE_4_PARAMS;
 
             let mut our_instance = Instance::new(&params_4_to_1);
-            let our_result = our_instance.n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+            let our_result = our_instance.n_to_1_fixed_hash(&[elem_1, elem_2, elem_3, elem_4, elem_5]);
 
             let mut unoptimized_instance = Instance::new(&params_4_to_1);
             let unoptimized_result =
-                unoptimized_instance.unoptimized_n_to_1_fixed_hash(vec![elem_1, elem_2, elem_3, elem_4, elem_5]);
+                unoptimized_instance.unoptimized_n_to_1_fixed_hash([elem_1, elem_2, elem_3, elem_4, elem_5]);
 
             assert_eq!(unoptimized_result, our_result);
         }


### PR DESCRIPTION
This fixes the previously broken `poseidon-consistency` crate and adds a benchmark for a 4:1 fixed width hash to the README